### PR TITLE
[POC] Local storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+This project isn't currently versioned, so for now each PR will act as a "version".
+
+## [ipfs-shipyard/space#21] - 2023-02-16
+
+### Added
+
+- Added a `local-storage` crate which exposes a `Storage` struct used to store & retrieve blocks from sqlite.
+- Implemented `TransmitDag` API for transmitting blocks from storage.
+- Modified receive functionality to use `local-storage` instead of streaming blocks to a file or storing incomplete blocks in-memory.
+- Implemented `ImportFile` and `ExportDag` APIs for controllable importing/exporting files to & from storage.
+- Added a `listen` flag to the `app-api-cli` for receiving responses to transmitted API messages.
+
+### Fixed
+
+- Fixed a compile issue with the `app-api-cli`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
+name = "assert_fs"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d94b2a3f3786ff2996a98afbd6b4e5b7e890d685ccf67577f508ee2342c71cc9"
+dependencies = [
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +368,7 @@ dependencies = [
  "cid 0.9.0",
  "futures",
  "iroh-unixfs",
+ "local-storage",
  "messages",
  "parity-scale-codec",
  "parity-scale-codec-derive",
@@ -368,13 +383,16 @@ name = "block-streamer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_fs",
  "block-ship",
  "bytes",
  "cid 0.9.0",
  "clap",
  "futures",
  "iroh-unixfs",
+ "local-storage",
  "messages",
+ "names",
  "parity-scale-codec",
  "parity-scale-codec-derive",
  "rand 0.8.5",
@@ -389,6 +407,16 @@ name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+
+[[package]]
+name = "bstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f0778972c64420fdedc63f09919c8a88bda7b25135357fd25a5d9f3257e832"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -856,6 +884,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +934,12 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dtoa"
@@ -989,6 +1029,18 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastmurmur3"
@@ -1182,6 +1234,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
+name = "globset"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,6 +1295,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+dependencies = [
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1415,6 +1500,23 @@ checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2157,6 +2259,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2176,6 +2289,21 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "local-storage"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_fs",
+ "cid 0.9.0",
+ "futures",
+ "iroh-unixfs",
+ "rusqlite",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "lock_api"
@@ -2269,6 +2397,7 @@ dependencies = [
 name = "messages"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "parity-scale-codec",
  "parity-scale-codec-derive",
@@ -2937,6 +3066,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
 name = "portable-atomic"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,6 +3082,33 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "itertools",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -3465,6 +3627,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3546,6 +3722,15 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -3936,6 +4121,12 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 
 [[package]]
 name = "thiserror"
@@ -4447,6 +4638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4457,6 +4654,17 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ members = [
     "car-utility",
     "local-dev-environment/desktop/radio-service",
     "messages",
-    "cpp-transmit-example"
+    "cpp-transmit-example",
+    "local-storage"
 ]

--- a/app-api-cli/Cargo.toml
+++ b/app-api-cli/Cargo.toml
@@ -12,4 +12,4 @@ messages = { path = "../messages" }
 serde_cbor_2 = "0.12.0-dev"
 serde_json = "1"
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive", "std"] }
-tokio = { version = "1", features = ["fs", "io-util"] }
+tokio = { version = "1", features = ["net", "rt", "macros"] }

--- a/block-ship/Cargo.toml
+++ b/block-ship/Cargo.toml
@@ -11,6 +11,7 @@ bytes = "1.1"
 cid = {version = "0.9", features = ["scale-codec"] }
 futures = "0.3.21"
 iroh-unixfs = "0.2.0"
+local-storage = { path = "../local-storage" }
 messages = { path = "../messages" }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"] }
 parity-scale-codec-derive = "3.1.3"

--- a/block-ship/src/chunking.rs
+++ b/block-ship/src/chunking.rs
@@ -7,6 +7,7 @@ use iroh_unixfs::{
     builder::{File, FileBuilder},
     Block,
 };
+use local_storage::storage::StoredBlock;
 use messages::TransmissionMessage;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
@@ -41,7 +42,7 @@ pub async fn path_to_chunks(path: &PathBuf) -> Result<Vec<TransmissionMessage>> 
     blocks.shuffle(&mut thread_rng());
 
     for block in blocks {
-        let wrapper = BlockWrapper::from_block(block)?;
+        let wrapper = BlockWrapper::from(block);
         let chunks = wrapper.to_chunks()?;
         for c in chunks {
             payloads.push(c);
@@ -49,6 +50,11 @@ pub async fn path_to_chunks(path: &PathBuf) -> Result<Vec<TransmissionMessage>> 
     }
 
     Ok(payloads)
+}
+
+pub fn stored_block_to_chunks(block: &StoredBlock) -> Result<Vec<TransmissionMessage>> {
+    let wrapper = BlockWrapper::try_from(block)?;
+    wrapper.to_chunks()
 }
 
 pub async fn chunks_to_path(

--- a/block-streamer/Cargo.toml
+++ b/block-streamer/Cargo.toml
@@ -12,6 +12,7 @@ bytes = "1.1"
 cid = {version = "0.9", features = ["scale-codec"] }
 clap = { version = "4.0.15", features = ["derive"] }
 futures = "0.3.21"
+local-storage = { path = "../local-storage" }
 iroh-unixfs = "0.2.0"
 messages = { path = "../messages" }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive", "std"] }
@@ -21,3 +22,7 @@ serde = "1"
 tokio = { version = "1", features = ["fs", "io-util"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
+
+[dev-dependencies]
+assert_fs = "1"
+names = { version = "0.14", default-features = false }

--- a/block-streamer/src/control.rs
+++ b/block-streamer/src/control.rs
@@ -1,39 +1,50 @@
 use anyhow::Result;
+use local_storage::provider::SqliteStorageProvider;
+use local_storage::storage::Storage;
 use parity_scale_codec::Decode;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::thread::sleep;
+use std::rc::Rc;
 use std::time::Duration;
 use tokio::net::UdpSocket;
+use tokio::time::sleep;
 use tracing::{error, info};
 
 use crate::receive::receive;
 use crate::receiver::Receiver;
-use crate::transmit::transmit;
+use crate::transmit::{transmit, transmit_blocks};
 use messages::{ApplicationAPI, Message};
 
 // TODO: Make this configurable
-pub const MTU: usize = 60;
+pub const MTU: usize = 1024; // 60 for radio
 
 pub async fn control(listen_addr: &String) -> Result<()> {
     info!("Listening for messages on {}", listen_addr);
     let listen_address: SocketAddr = listen_addr.parse()?;
 
+    // Setup storage
+    let provider = SqliteStorageProvider::new("storage.db")?;
+    provider.setup()?;
+    let storage = Rc::new(Storage::new(Box::new(provider)));
+
     let mut buf = vec![0; MTU];
     let mut real_len;
-    let mut data_receiver = Receiver::new();
+    let mut data_receiver = Receiver::new(Rc::clone(&storage));
+    let mut sender_addr;
 
     let socket = UdpSocket::bind(&listen_address).await?;
+
     loop {
         {
             loop {
-                if let Ok(len) = socket.try_recv(&mut buf) {
+                if let Ok((len, sender)) = socket.try_recv_from(&mut buf) {
                     if len > 0 {
                         real_len = len;
+                        sender_addr = Some(sender);
                         break;
                     }
                 }
-                sleep(Duration::from_millis(10));
+                sleep(Duration::from_millis(10)).await;
             }
         }
 
@@ -45,9 +56,41 @@ pub async fn control(listen_addr: &String) -> Result<()> {
             Ok(Message::ApplicationAPI(ApplicationAPI::TransmitFile { path, target_addr })) => {
                 transmit(&PathBuf::from(path), &target_addr).await?
             }
+            Ok(Message::ApplicationAPI(ApplicationAPI::TransmitDag { cid, target_addr })) => {
+                let root_block = storage.get_block_by_cid(&cid)?;
+                let blocks = storage.get_all_blocks_under_cid(&cid)?;
+                let mut all_blocks = vec![root_block];
+                all_blocks.extend(blocks);
+                transmit_blocks(&all_blocks, &target_addr).await?;
+            }
+            Ok(Message::ApplicationAPI(ApplicationAPI::ImportFile { path })) => {
+                let root_cid = storage.import_path(&PathBuf::from(path.to_owned())).await?;
+                let response = Message::ApplicationAPI(ApplicationAPI::FileImported {
+                    path: path.to_string(),
+                    cid: root_cid.to_string(),
+                });
+                if let Some(sender_addr) = sender_addr {
+                    socket.send_to(&response.to_bytes(), sender_addr).await?;
+                }
+            }
+            Ok(Message::ApplicationAPI(ApplicationAPI::ExportDag { cid, path })) => {
+                storage.export_cid(&cid, &PathBuf::from(path)).await?
+            }
+            Ok(Message::ApplicationAPI(ApplicationAPI::RequestAvailableBlocks)) => {
+                let raw_cids = storage.list_available_cids()?;
+                let cids = raw_cids
+                    .iter()
+                    .map(|c| c.to_string())
+                    .collect::<Vec<String>>();
+
+                if let Some(sender_addr) = sender_addr {
+                    let response =
+                        Message::ApplicationAPI(ApplicationAPI::AvailableBlocks { cids });
+                    socket.send_to(&response.to_bytes(), sender_addr).await?;
+                }
+            }
             Ok(Message::DataProtocol(data_msg)) => {
                 data_receiver.handle_transmission_msg(data_msg).await?;
-                data_receiver.attempt_tree_assembly().await?;
             }
             Ok(message) => {
                 info!("Received unhandled message: {:?}", message);

--- a/block-streamer/src/transmit.rs
+++ b/block-streamer/src/transmit.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
-use block_ship::chunking::path_to_chunks;
+use block_ship::chunking::{path_to_chunks, stored_block_to_chunks};
+use local_storage::storage::StoredBlock;
 use messages::Message;
+use messages::TransmissionMessage;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use tokio::net::UdpSocket;
@@ -23,5 +25,29 @@ pub async fn transmit(path: &PathBuf, target_addr: &String) -> Result<()> {
         info!("Transmitting {} bytes", packet_bytes.len());
         socket.send_to(&packet_bytes, target_address).await?;
     }
+    Ok(())
+}
+
+pub async fn transmit_blocks(blocks: &[StoredBlock], target_addr: &String) -> Result<()> {
+    info!("Transmitting {} blocks to {}", blocks.len(), target_addr);
+
+    let target_address: SocketAddr = target_addr.parse()?;
+    let bind_address: SocketAddr = "127.0.0.1:0".parse()?;
+    let socket = UdpSocket::bind(&bind_address).await?;
+    let data: Vec<TransmissionMessage> = blocks
+        .iter()
+        .map(|b| stored_block_to_chunks(b))
+        // TODO: properly handle & log errors
+        .filter_map(|list| list.ok())
+        .flatten()
+        .collect();
+
+    for packet in data {
+        let msg = Message::DataProtocol(packet);
+        let packet_bytes = msg.to_bytes();
+        info!("Transmitting {} bytes", packet_bytes.len());
+        socket.send_to(&packet_bytes, target_address).await?;
+    }
+
     Ok(())
 }

--- a/local-storage/Cargo.toml
+++ b/local-storage/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "local-storage"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"
+cid = "0.9"
+futures = "0.3.21"
+iroh-unixfs = "0.2.0"
+rusqlite = { version = "0.28.0", features = ["bundled"] }
+thiserror = "1"
+tokio = "1"
+tracing = "0.1"
+
+[dev-dependencies]
+assert_fs = "1"

--- a/local-storage/Cross.toml
+++ b/local-storage/Cross.toml
@@ -1,0 +1,2 @@
+[target.armv7-unknown-linux-gnueabihf]
+dockerfile = "../Dockerfile"

--- a/local-storage/src/error.rs
+++ b/local-storage/src/error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StorageError {
+    #[error("Block not found for CID {0}: {1}")]
+    BlockNotFound(String, String),
+    #[error("DAG incomplete {0}")]
+    DagIncomplete(String),
+}

--- a/local-storage/src/lib.rs
+++ b/local-storage/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod error;
+pub mod provider;
+pub mod storage;

--- a/local-storage/src/provider.rs
+++ b/local-storage/src/provider.rs
@@ -1,0 +1,382 @@
+use crate::{error::StorageError, storage::StoredBlock};
+
+use anyhow::{bail, Result};
+use rusqlite::Connection;
+
+pub trait StorageProvider {
+    // Import a stored block
+    fn import_block(&self, block: &StoredBlock) -> Result<()>;
+    // Requests a list of CIDs currently available in storage
+    fn get_available_cids(&self) -> Result<Vec<String>>;
+    // Requests the block associated with the given CID
+    fn get_block_by_cid(&self, cid: &str) -> Result<StoredBlock>;
+    // Requests the links associated with the given CID
+    fn get_links_by_cid(&self, cid: &str) -> Result<Vec<String>>;
+    fn list_available_dags(&self) -> Result<Vec<String>>;
+    fn get_missing_cid_blocks(&self, cid: &str) -> Result<Vec<String>>;
+}
+
+pub struct SqliteStorageProvider {
+    conn: Box<Connection>,
+}
+
+impl SqliteStorageProvider {
+    pub fn new(db_path: &str) -> Result<Self> {
+        Ok(SqliteStorageProvider {
+            conn: Box::new(Connection::open(db_path)?),
+        })
+    }
+
+    pub fn setup(&self) -> Result<()> {
+        // Create blocks table
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS blocks (
+                id INTEGER PRIMARY KEY,
+                cid TEXT NOT NULL,
+                data BLOB
+            )",
+            (),
+        )?;
+
+        // Create links table
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS links(
+                id INTEGER PRIMARY KEY,
+                root_cid TEXT,
+                block_cid TEXT NOT NULL,
+                block_id INTEGER,
+                FOREIGN KEY (block_id) REFERENCES blocks (id)
+            )",
+            (),
+        )?;
+
+        // Create indices
+        self.conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS blocks_cid on blocks(cid)",
+            (),
+        )?;
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS links_root_cid on links(root_cid)",
+            (),
+        )?;
+        self.conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS links_block_cid on links(block_cid)",
+            (),
+        )?;
+
+        Ok(())
+    }
+}
+
+impl StorageProvider for SqliteStorageProvider {
+    fn import_block(&self, block: &StoredBlock) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO blocks (cid, data) VALUES (?1, ?2)",
+            (&block.cid, &block.data),
+        )?;
+        // TODO: Should we have another indicator for root blocks that isn't just the number of links?
+        // TODO: This logic should probably get pulled up and split into two parts:
+        // 1. import_block - Handles importing block into block store
+        // 2. import_block_links - Handles correctly updating links store to account for block
+        // If root block with links, then insert links
+        if !block.links.is_empty() {
+            for link_cid in &block.links {
+                let mut maybe_block_id = None;
+                if let Ok(block_id) = self.conn.query_row(
+                    "SELECT id FROM blocks b
+                    WHERE cid == (?1)",
+                    [link_cid],
+                    |row| {
+                        let id: u32 = row.get(0).unwrap();
+                        Ok(id)
+                    },
+                ) {
+                    maybe_block_id = Some(block_id);
+                }
+                self.conn.execute(
+                    "INSERT INTO links (root_cid, block_cid, block_id) VALUES(?1, ?2, ?3)",
+                    (&block.cid, link_cid, maybe_block_id),
+                )?;
+            }
+        } else {
+            // If child block w/out links...then check if the ID should be inserted into the links table
+            self.conn.execute(
+                "UPDATE links SET block_id = (SELECT id from blocks WHERE cid = ?1) WHERE block_cid = ?2",
+                (&block.cid, &block.cid),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn get_available_cids(&self) -> Result<Vec<String>> {
+        let cids: Vec<String> = self
+            .conn
+            .prepare("SELECT cid FROM blocks")?
+            .query_map([], |row| row.get(0))?
+            // TODO: Correctly catch and log/handle errors here
+            .filter_map(|cid| cid.ok())
+            .collect();
+        Ok(cids)
+    }
+
+    fn get_links_by_cid(&self, cid: &str) -> Result<Vec<String>> {
+        let links: Vec<String> = self
+            .conn
+            .prepare("SELECT block_cid FROM links WHERE root_cid == (?1)")?
+            .query_map([cid], |row| {
+                let cid_str: String = row.get(0)?;
+                Ok(cid_str)
+            })?
+            // TODO: Correctly catch/log/handle errors here
+            .filter_map(|cid| cid.ok())
+            .collect();
+        Ok(links)
+    }
+
+    fn get_block_by_cid(&self, cid: &str) -> Result<StoredBlock> {
+        match self.conn.query_row(
+            "SELECT cid, data FROM blocks b
+            WHERE cid == (?1)",
+            [&cid],
+            |row| {
+                let cid_str: String = row.get(0).unwrap();
+                let data: Vec<u8> = row.get(1).unwrap();
+                Ok(StoredBlock {
+                    cid: cid_str,
+                    data,
+                    links: vec![],
+                })
+            },
+        ) {
+            Ok(mut block) => {
+                block.links = self.get_links_by_cid(cid)?;
+                Ok(block)
+            }
+            Err(e) => bail!(StorageError::BlockNotFound(cid.to_string(), e.to_string())),
+        }
+    }
+
+    fn list_available_dags(&self) -> Result<Vec<String>> {
+        let roots = self
+            .conn
+            .prepare("SELECT DISTINCT root_cid FROM links")?
+            .query_map([], |row| {
+                let cid_str: String = row.get(0)?;
+                Ok(cid_str)
+            })?
+            // TODO: Correctly catch/log/handle errors here
+            .filter_map(|cid| cid.ok())
+            .collect();
+        Ok(roots)
+    }
+
+    fn get_missing_cid_blocks(&self, cid: &str) -> Result<Vec<String>> {
+        let cids = self
+            .conn
+            .prepare("SELECT block_cid FROM links WHERE root_cid == (?1) AND block_id IS NULL")?
+            .query_map([cid], |row| {
+                let cid_str: String = row.get(0)?;
+                Ok(cid_str)
+            })?
+            // TODO: Correctly catch/log/handle errors here
+            .filter_map(|cid| cid.ok())
+            .collect();
+        Ok(cids)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    use assert_fs::{fixture::PathChild, TempDir};
+    use cid::multihash::MultihashDigest;
+    use cid::Cid;
+
+    struct TestHarness {
+        provider: SqliteStorageProvider,
+        _db_dir: TempDir,
+    }
+
+    impl TestHarness {
+        pub fn new() -> Self {
+            let db_dir = TempDir::new().unwrap();
+            let db_path = db_dir.child("storage.db");
+            let provider = SqliteStorageProvider::new(db_path.path().to_str().unwrap()).unwrap();
+            provider.setup().unwrap();
+            return TestHarness {
+                provider,
+                _db_dir: db_dir,
+            };
+        }
+    }
+
+    #[test]
+    pub fn test_create_sqlite_provider() {
+        let db_dir = TempDir::new().unwrap();
+        let db_path = db_dir.child("storage.db");
+        let provider = SqliteStorageProvider::new(db_path.to_str().unwrap()).unwrap();
+        provider.setup().unwrap();
+    }
+
+    #[test]
+    pub fn test_import_one_block() {
+        let harness = TestHarness::new();
+
+        let cid = Cid::new_v1(0x55, cid::multihash::Code::Sha2_256.digest(b"00"));
+        let cid_str = cid.to_string();
+        let block = StoredBlock {
+            cid: cid_str.to_string(),
+            data: b"1010101".to_vec(),
+            links: vec![],
+        };
+
+        harness.provider.import_block(&block).unwrap();
+        let cids_list = harness.provider.get_available_cids().unwrap();
+        assert_eq!(cids_list.len(), 1);
+        assert_eq!(cids_list.first().unwrap(), &cid_str);
+    }
+
+    #[test]
+    pub fn test_import_three_blocks() {
+        use std::collections::HashSet;
+        use std::iter::FromIterator;
+
+        let harness = TestHarness::new();
+
+        let seeds = vec![b"00", b"11", b"22"];
+        let cids: Vec<String> = seeds
+            .iter()
+            .map(|s| {
+                Cid::new_v1(0x55, cid::multihash::Code::Sha2_256.digest(s.as_slice())).to_string()
+            })
+            .collect();
+
+        cids.iter().for_each(|c| {
+            let block = StoredBlock {
+                cid: c.to_string(),
+                data: b"123412341234".to_vec(),
+                links: vec![],
+            };
+            harness.provider.import_block(&block).unwrap()
+        });
+
+        let cids_list = harness.provider.get_available_cids().unwrap();
+        assert_eq!(cids_list.len(), 3);
+        let set_one: HashSet<&String> = HashSet::from_iter(cids.iter());
+        let set_two: HashSet<&String> = HashSet::from_iter(cids_list.iter());
+        assert_eq!(set_one, set_two);
+    }
+
+    #[test]
+    pub fn test_import_then_get_block() {
+        let harness = TestHarness::new();
+
+        let cid = Cid::new_v1(0x55, cid::multihash::Code::Sha2_256.digest(b"00"));
+
+        let block = StoredBlock {
+            cid: cid.to_string(),
+            data: b"1010101".to_vec(),
+            links: vec![],
+        };
+
+        harness.provider.import_block(&block).unwrap();
+        let cids_list = harness.provider.get_available_cids().unwrap();
+        let cid_str = cids_list.first().unwrap();
+
+        let fetched_block = harness.provider.get_block_by_cid(cid_str).unwrap();
+        assert_eq!(block, fetched_block);
+    }
+
+    #[test]
+    pub fn test_import_then_get_root_block() {
+        let harness = TestHarness::new();
+
+        let cid = Cid::new_v1(0x55, cid::multihash::Code::Sha2_256.digest(b"00"));
+        let block_cid = Cid::new_v1(0x55, cid::multihash::Code::Sha2_256.digest(b"11"));
+
+        let block = StoredBlock {
+            cid: cid.to_string(),
+            data: b"1010101".to_vec(),
+            links: vec![block_cid.to_string()],
+        };
+
+        harness.provider.import_block(&block).unwrap();
+        let cids_list = harness.provider.get_available_cids().unwrap();
+        let cid_str = cids_list.first().unwrap();
+
+        let fetched_block = harness.provider.get_block_by_cid(cid_str).unwrap();
+        assert_eq!(block, fetched_block);
+    }
+
+    #[test]
+    pub fn test_verify_detect_missing_blocks() {
+        let harness = TestHarness::new();
+
+        let cid = Cid::new_v1(0x55, cid::multihash::Code::Sha2_256.digest(b"00"));
+        let block_cid = Cid::new_v1(0x55, cid::multihash::Code::Sha2_256.digest(b"11"));
+
+        let block = StoredBlock {
+            cid: cid.to_string(),
+            data: vec![],
+            links: vec![block_cid.to_string()],
+        };
+
+        harness.provider.import_block(&block).unwrap();
+        let cids_list = harness.provider.get_available_cids().unwrap();
+        let cid_str = cids_list.first().unwrap();
+
+        let fetched_block = harness.provider.get_block_by_cid(cid_str).unwrap();
+        assert_eq!(block, fetched_block);
+        assert_eq!(harness.provider.get_links_by_cid(cid_str).unwrap().len(), 1);
+        assert_eq!(
+            harness
+                .provider
+                .get_missing_cid_blocks(cid_str)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    pub fn test_verify_detect_no_missing_blocks() {
+        let harness = TestHarness::new();
+
+        let cid = Cid::new_v1(0x55, cid::multihash::Code::Sha2_256.digest(b"00"));
+        let cid_str = cid.to_string();
+        let block_cid = Cid::new_v1(0x55, cid::multihash::Code::Sha2_256.digest(b"11"));
+
+        let block = StoredBlock {
+            cid: cid_str.to_string(),
+            data: vec![],
+            links: vec![block_cid.to_string()],
+        };
+
+        let child_block = StoredBlock {
+            cid: block_cid.to_string(),
+            data: b"101293910101".to_vec(),
+            links: vec![],
+        };
+
+        harness.provider.import_block(&block).unwrap();
+        harness.provider.import_block(&child_block).unwrap();
+        let cids_list = harness.provider.get_available_cids().unwrap();
+        assert_eq!(cids_list.len(), 2);
+
+        let fetched_block = harness.provider.get_block_by_cid(&cid_str).unwrap();
+        assert_eq!(block, fetched_block);
+        assert_eq!(
+            harness.provider.get_links_by_cid(&cid_str).unwrap().len(),
+            1
+        );
+        assert_eq!(
+            harness
+                .provider
+                .get_missing_cid_blocks(&cid_str)
+                .unwrap()
+                .len(),
+            0
+        );
+    }
+}

--- a/local-storage/src/storage.rs
+++ b/local-storage/src/storage.rs
@@ -1,0 +1,183 @@
+use crate::error::StorageError;
+use crate::provider::StorageProvider;
+
+use anyhow::{bail, Result};
+use futures::TryStreamExt;
+use iroh_unixfs::builder::{File, FileBuilder};
+use std::path::Path;
+use tokio::fs::File as TokioFile;
+use tokio::io::AsyncWriteExt;
+use tracing::info;
+
+pub struct Storage {
+    pub provider: Box<dyn StorageProvider>,
+}
+
+impl Storage {
+    pub fn new(provider: Box<dyn StorageProvider>) -> Self {
+        Storage { provider }
+    }
+
+    pub async fn import_path(&self, path: &Path) -> Result<String> {
+        let file: File = FileBuilder::new()
+            .path(path)
+            .fixed_chunker(50)
+            .build()
+            .await?;
+        let blocks: Vec<_> = file.encode().await?.try_collect().await?;
+        let mut root_cid: Option<String> = None;
+
+        blocks.iter().for_each(|b| {
+            let links = b
+                .links()
+                .iter()
+                .map(|c| c.to_string())
+                .collect::<Vec<String>>();
+            let stored = StoredBlock {
+                cid: b.cid().to_string(),
+                data: b.data().to_vec(),
+                links,
+            };
+            self.provider.import_block(&stored).unwrap();
+            if !stored.links.is_empty() {
+                root_cid = Some(stored.cid);
+            }
+        });
+        if let Some(root_cid) = root_cid {
+            info!("Imported path {} to {}", path.display(), root_cid);
+            Ok(root_cid)
+        } else {
+            bail!("Failed to find root block for {path:?}")
+        }
+    }
+
+    pub async fn export_cid(&self, cid: &str, path: &Path) -> Result<()> {
+        info!("Exporting {cid} to {}", path.display());
+        let check_missing_blocks = self.get_missing_dag_blocks(cid)?;
+        if !check_missing_blocks.is_empty() {
+            bail!(StorageError::DagIncomplete(cid.to_string()))
+        }
+        // Fetch all blocks tied to links under given cid
+        let child_blocks = self.get_all_blocks_under_cid(cid)?;
+        // Open up file path for writing
+        let mut output_file = TokioFile::create(path).await?;
+        // Walk the StoredBlocks and write out to path
+        for block in child_blocks {
+            output_file.write_all(&block.data).await?;
+        }
+        output_file.flush().await?;
+        Ok(())
+    }
+
+    pub fn list_available_cids(&self) -> Result<Vec<String>> {
+        // Query list of available CIDs
+        // Include all root and child CIDs?
+        self.provider.get_available_cids()
+    }
+
+    pub fn get_block_by_cid(&self, cid: &str) -> Result<StoredBlock> {
+        // Check if CID+block exists
+        // Return block if exists
+        self.provider.get_block_by_cid(cid)
+    }
+
+    pub fn get_all_blocks_under_cid(&self, cid: &str) -> Result<Vec<StoredBlock>> {
+        // Get StoredBlock by cid and check for links
+        let root_block = self.provider.get_block_by_cid(cid)?;
+        // If links, grab all appropriate StoredBlocks
+        let mut child_blocks = vec![];
+        for link in root_block.links {
+            child_blocks.push(self.provider.get_block_by_cid(&link)?);
+        }
+        Ok(child_blocks)
+    }
+
+    pub fn import_block(&self, block: &StoredBlock) -> Result<()> {
+        info!("Importing block {}", block.cid);
+        self.provider.import_block(block)
+    }
+
+    pub fn get_missing_dag_blocks(&self, cid: &str) -> Result<Vec<String>> {
+        self.provider.get_missing_cid_blocks(cid)
+    }
+
+    pub fn list_available_dags(&self) -> Result<Vec<String>> {
+        self.provider.list_available_dags()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct StoredBlock {
+    pub cid: String,
+    pub data: Vec<u8>,
+    pub links: Vec<String>,
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::provider::SqliteStorageProvider;
+    use assert_fs::{fixture::FileWriteBin, fixture::PathChild, TempDir};
+
+    struct TestHarness {
+        storage: Storage,
+        _db_dir: TempDir,
+    }
+
+    impl TestHarness {
+        pub fn new() -> Self {
+            let db_dir = TempDir::new().unwrap();
+            let db_path = db_dir.child("storage.db");
+            let provider = SqliteStorageProvider::new(db_path.path().to_str().unwrap()).unwrap();
+            provider.setup().unwrap();
+            let storage = Storage::new(Box::new(provider));
+            return TestHarness {
+                storage,
+                _db_dir: db_dir,
+            };
+        }
+    }
+
+    #[tokio::test]
+    pub async fn test_import_path_to_storage() {
+        let harness = TestHarness::new();
+
+        let temp_dir = assert_fs::TempDir::new().unwrap();
+        let test_file = temp_dir.child("data.txt");
+        test_file
+            .write_binary(
+                b"654684646847616846846876168468416874616846416846846186468464684684648684684",
+            )
+            .unwrap();
+        let root_cid = harness.storage.import_path(test_file.path()).await.unwrap();
+
+        let available_cids = harness.storage.list_available_cids().unwrap();
+
+        assert!(available_cids.contains(&root_cid));
+    }
+
+    #[tokio::test]
+    pub async fn export_path_from_storage() {
+        let harness = TestHarness::new();
+
+        let temp_dir = assert_fs::TempDir::new().unwrap();
+        let test_file = temp_dir.child("data.txt");
+        test_file
+            .write_binary(
+                b"654684646847616846846876168468416874616846416846846186468464684684648684684",
+            )
+            .unwrap();
+        let cid = harness.storage.import_path(test_file.path()).await.unwrap();
+
+        let next_test_file = temp_dir.child("output.txt");
+        harness
+            .storage
+            .export_cid(&cid, next_test_file.path())
+            .await
+            .unwrap();
+
+        let test_file_contents = std::fs::read_to_string(test_file.path()).unwrap();
+        let next_test_file_contents = std::fs::read_to_string(next_test_file.path()).unwrap();
+        assert_eq!(test_file_contents, next_test_file_contents);
+    }
+}

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1"
 clap = { version = "4.0.15", features = ["derive"] }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive", "std"] }
 parity-scale-codec-derive = "3.1.3"

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -34,7 +34,7 @@ pub enum ApplicationAPI {
     /// Asks IPFS instance to import a file path into the local IPFS store
     ImportFile { path: String },
     /// Response message to ImportFile containing file's root CID
-    ImportFileResult { path: String, cid: String },
+    FileImported { path: String, cid: String },
     /// Asks IPFS instance to attempt to export a DAG to a file path
     ExportDag { cid: String, path: String },
     /// Tells IPFS instance whether comms are connected or not
@@ -44,9 +44,9 @@ pub enum ApplicationAPI {
     /// Chunks and initiates transmission of a file path to destination IP
     TransmitFile { path: String, target_addr: String },
     /// Initiates transmission of DAG corresponding to the given CID
-    TransmitDag { cid: String },
+    TransmitDag { cid: String, target_addr: String },
     /// Initiates transmission of block corresponding to the given CID
-    TransmitBlock { cid: String },
+    TransmitBlock { cid: String, target_addr: String },
     /// Listens on address for data and writes out files received
     Receive { listen_addr: String },
     /// Verify that a block exists on the system and is valid


### PR DESCRIPTION
### Added

- Added a `local-storage` crate which exposes a `Storage` struct used to store & retrieve blocks from sqlite.
- Implemented `TransmitDag` API for transmitting blocks from storage.
- Modified receive functionality to use `local-storage` instead of streaming blocks to a file or storing incomplete blocks in-memory.
- Implemented `ImportFile` and `ExportDag` APIs for controllable importing/exporting files to & from storage.
- Added a `listen` flag to the `app-api-cli` for receiving responses to transmitted API messages.

### Fixed

- Fixed a compile issue with the `app-api-cli`