### PR TITLE
[POC] Adding block and dag validation functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [0.5] - Unreleased
 
+### Added
+
+- Added `validate` for `StoredBlock` to leverage the validation functionality built into `beetle::iroh_unixfs::Block`.
+- Added `local_storage::block::validate_dag` which determines if a list of `StoredBlock`s constitute a complete and valid DAG.
+
+### Changed
+
+- Moved `StoredBlock` and associated implementation/tests out of the `storage` mod into a `block` mod within `local-storage`.
+
 ### Removed
 
 - The `RequestDag` and `RequestBlock` APIs were removed, as they were essentially equivalent to `TransmitDag` and `TransmitBlock`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,6 +1942,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "libipld"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ccd6b8ffb3afee7081fcaec00e1b099fd1c7ccf35ba5729d88538fcc3b4599"
+dependencies = [
+ "fnv",
+ "libipld-cbor 0.16.0",
+ "libipld-cbor-derive 0.16.0",
+ "libipld-core 0.16.0",
+ "libipld-json 0.16.0",
+ "libipld-macro 0.16.0",
+ "libipld-pb 0.16.0",
+ "log",
+ "multihash 0.18.0",
+ "thiserror",
+]
+
+[[package]]
 name = "libipld-cbor"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,6 +1982,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libipld-cbor"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77d98c9d1747aa5eef1cf099cd648c3fd2d235249f5fed07522aaebc348e423b"
+dependencies = [
+ "byteorder",
+ "libipld-core 0.16.0",
+ "thiserror",
+]
+
+[[package]]
 name = "libipld-cbor-derive"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,6 +2010,19 @@ name = "libipld-cbor-derive"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4515686b6bffd663a1fbdd87408ced5b612751910a9e309042e9efef9dbdb324"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "libipld-cbor-derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5ba3a729b72973e456a1812b0afe2e176a376c1836cc1528e9fc98ae8cb838"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2018,6 +2060,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "libipld-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5acd707e8d8b092e967b2af978ed84709eaded82b75effe6cb6f6cc797ef8158"
+dependencies = [
+ "anyhow",
+ "cid 0.10.1",
+ "core2",
+ "multibase",
+ "multihash 0.18.0",
+ "thiserror",
+]
+
+[[package]]
 name = "libipld-json"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,6 +2098,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libipld-json"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25856def940047b07b25c33d4e66d248597049ab0202085215dc4dca0487731c"
+dependencies = [
+ "libipld-core 0.16.0",
+ "multihash 0.18.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "libipld-macro"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,6 +2125,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c7ccd89e54f2796cf3f99aabeea7a7751d418df504926544f28348d3c890c7"
 dependencies = [
  "libipld-core 0.15.0",
+]
+
+[[package]]
+name = "libipld-macro"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71171c54214f866ae6722f3027f81dff0931e600e5a61e6b1b6a49ca0b5ed4ae"
+dependencies = [
+ "libipld-core 0.16.0",
 ]
 
 [[package]]
@@ -2079,6 +2156,18 @@ checksum = "dd84ee8b7e283c81b28ecf46e07c31a524a2cd35ec4e87833733a18218c17ccb"
 dependencies = [
  "libipld-core 0.15.0",
  "prost 0.11.3",
+ "thiserror",
+]
+
+[[package]]
+name = "libipld-pb"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f2d0f866c4cd5dc9aa8068c429ba478d2882a3a4b70ab56f7e9a0eddf5d16f"
+dependencies = [
+ "bytes",
+ "libipld-core 0.16.0",
+ "quick-protobuf",
  "thiserror",
 ]
 
@@ -2275,9 +2364,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_fs",
+ "bytes",
  "cid 0.9.0",
  "futures",
  "iroh-unixfs",
+ "libipld 0.16.0",
  "rusqlite",
  "thiserror",
  "tokio",
@@ -3345,6 +3436,15 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-protobuf"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "quote"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,6 +2369,7 @@ dependencies = [
  "futures",
  "iroh-unixfs",
  "libipld 0.16.0",
+ "rand 0.8.5",
  "rusqlite",
  "thiserror",
  "tokio",

--- a/block-streamer/src/transmit.rs
+++ b/block-streamer/src/transmit.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use cid::Cid;
-use local_storage::storage::StoredBlock;
+use local_storage::block::StoredBlock;
 use messages::chunking::{MessageChunker, SimpleChunker};
 use messages::Message;
 use messages::TransmissionBlock;

--- a/local-storage/Cargo.toml
+++ b/local-storage/Cargo.toml
@@ -8,8 +8,10 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 cid = "0.9"
+bytes = "1"
 futures = "0.3.21"
 iroh-unixfs = "0.2.0"
+libipld = "0.16"
 rusqlite = { version = "0.28.0", features = ["bundled"] }
 thiserror = "1"
 tokio = "1"

--- a/local-storage/Cargo.toml
+++ b/local-storage/Cargo.toml
@@ -19,3 +19,4 @@ tracing = "0.1"
 
 [dev-dependencies]
 assert_fs = "1"
+rand = "0.8"

--- a/local-storage/src/block.rs
+++ b/local-storage/src/block.rs
@@ -1,7 +1,8 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use bytes::Bytes;
 use cid::Cid;
 use iroh_unixfs::Block;
+use std::collections::HashSet;
 use std::str::FromStr;
 
 #[derive(Debug, PartialEq)]
@@ -13,18 +14,65 @@ pub struct StoredBlock {
 
 impl StoredBlock {
     pub fn validate(&self) -> Result<()> {
-        let real_cid = Cid::from_str(&self.cid)?;
-        let real_links = self
+        // For now we'll just piggy back on the validate logic built
+        // into n0/beetle:unixfs::Block
+        let block: Block = self.try_into()?;
+        block.validate()
+    }
+}
+
+impl TryInto<Block> for &StoredBlock {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> std::result::Result<Block, Self::Error> {
+        let cid = Cid::from_str(&self.cid)?;
+        let links = self
             .links
             .iter()
             .map(|l| Cid::from_str(l).unwrap())
             .collect::<Vec<Cid>>();
-        let real_data = Bytes::from(self.data.clone());
-        // For now we'll just piggy back on the validate logic built
-        // into n0/beetle:unixfs::Block
-        let block = Block::new(real_cid, real_data, real_links);
-        block.validate()
+        let data = Bytes::from(self.data.clone());
+        Ok(Block::new(cid, data, links))
     }
+}
+
+pub fn validate_dag(stored_blocks: Vec<StoredBlock>) -> Result<()> {
+    if stored_blocks.is_empty() {
+        bail!("No blocks found in dag")
+    }
+    let blocks = stored_blocks
+        .iter()
+        .map(|b| b.try_into().unwrap())
+        .collect::<Vec<Block>>();
+    // First check if all blocks are valid
+    for block in blocks.iter() {
+        block.validate()?;
+    }
+    // If there is only one block and it is validate....then ok
+    if blocks.len() == 1 {
+        return Ok(());
+    }
+    // Now find the root
+    let root = blocks.iter().find(|b| !b.links().is_empty());
+    if let Some(root) = root {
+        let child_cids = blocks
+            .iter()
+            .filter(|b| b.links().is_empty())
+            .map(|b| b.cid().to_string())
+            .collect::<HashSet<String>>();
+        let linked_cids = root
+            .links()
+            .iter()
+            .map(|l| l.to_string())
+            .collect::<HashSet<String>>();
+
+        if child_cids != linked_cids {
+            bail!("Links do not match blocks");
+        }
+    } else {
+        bail!("No root found")
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -32,15 +80,23 @@ mod tests {
     use super::*;
 
     use anyhow::anyhow;
+    use cid::multihash::MultihashDigest;
     use futures::TryStreamExt;
     use iroh_unixfs::builder::{File, FileBuilder};
     use libipld::error::InvalidMultihash;
+    use rand::{thread_rng, RngCore};
 
-    async fn generate_stored_blocks(data: Vec<u8>) -> Result<Vec<StoredBlock>> {
+    async fn generate_stored_blocks(num_blocks: u8) -> Result<Vec<StoredBlock>> {
+        const CHUNK_SIZE: u8 = 20;
+        let data_size = CHUNK_SIZE * num_blocks;
+        let mut data = Vec::<u8>::new();
+        data.resize(data_size.into(), 1);
+        thread_rng().fill_bytes(&mut data);
+
         let file: File = FileBuilder::new()
             .content_bytes(data)
             .name("testfile")
-            .fixed_chunker(20)
+            .fixed_chunker(CHUNK_SIZE.into())
             .build()
             .await?;
         let blocks: Vec<_> = file.encode().await?.try_collect().await?;
@@ -66,7 +122,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn test_valid_block_no_links() {
-        let blocks = generate_stored_blocks(vec![0; 10]).await.unwrap();
+        let blocks = generate_stored_blocks(1).await.unwrap();
         let stored_block = blocks.first().unwrap();
 
         assert!(stored_block.validate().is_ok());
@@ -74,7 +130,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn test_invalid_block_no_links() {
-        let mut blocks = generate_stored_blocks(vec![0; 10]).await.unwrap();
+        let mut blocks = generate_stored_blocks(1).await.unwrap();
         let mut stored_block = blocks.pop().unwrap();
         stored_block.data.extend(b"corruption");
 
@@ -86,7 +142,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn test_valid_block_with_links() {
-        let blocks = generate_stored_blocks(vec![15; 50]).await.unwrap();
+        let blocks = generate_stored_blocks(5).await.unwrap();
         let stored_block = blocks.last().unwrap();
 
         assert!(stored_block.links.len() > 0);
@@ -95,7 +151,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn test_valid_block_with_invalid_links() {
-        let mut blocks = generate_stored_blocks(vec![15; 50]).await.unwrap();
+        let mut blocks = generate_stored_blocks(7).await.unwrap();
         let stored_block = blocks.last_mut().unwrap();
 
         stored_block.links.pop();
@@ -105,5 +161,89 @@ mod tests {
             stored_block.validate().unwrap_err().to_string(),
             "links do not match"
         );
+    }
+
+    #[tokio::test]
+    pub async fn test_valid_dag_single_block() {
+        let blocks = generate_stored_blocks(1).await.unwrap();
+
+        assert!(validate_dag(blocks).is_ok());
+    }
+
+    #[tokio::test]
+    pub async fn test_valid_dag_multi_blocks() {
+        let blocks = generate_stored_blocks(10).await.unwrap();
+
+        assert!(validate_dag(blocks).is_ok());
+    }
+
+    #[tokio::test]
+    pub async fn test_dag_with_corrupt_block() {
+        let mut blocks = generate_stored_blocks(4).await.unwrap();
+
+        let first = blocks.first_mut().unwrap();
+        first.data.extend(b"corruption");
+
+        assert_eq!(
+            validate_dag(blocks).unwrap_err().to_string(),
+            "Hash of data does not match the CID."
+        );
+    }
+
+    #[tokio::test]
+    pub async fn test_dag_missing_block() {
+        let mut blocks = generate_stored_blocks(12).await.unwrap();
+
+        blocks.remove(0);
+
+        assert!(validate_dag(blocks).is_err());
+    }
+
+    #[tokio::test]
+    pub async fn test_dag_missing_root() {
+        let mut blocks = generate_stored_blocks(7).await.unwrap();
+
+        blocks.pop();
+
+        assert!(validate_dag(blocks).is_err());
+    }
+
+    #[tokio::test]
+    pub async fn test_dag_extra_block() {
+        let mut blocks = generate_stored_blocks(6).await.unwrap();
+
+        let data = b"1871217171".to_vec();
+        let cid = Cid::new_v1(0x55, cid::multihash::Code::Sha2_256.digest(&data));
+
+        blocks.push(StoredBlock {
+            cid: cid.to_string(),
+            data,
+            links: vec![],
+        });
+
+        assert!(validate_dag(blocks).is_err());
+    }
+
+    #[tokio::test]
+    pub async fn test_dag_with_wrong_block() {
+        let mut blocks = generate_stored_blocks(9).await.unwrap();
+
+        let data = b"1871217171".to_vec();
+        let cid = Cid::new_v1(0x55, cid::multihash::Code::Sha2_256.digest(&data));
+
+        // Remove a block and insert one which doesn't belong
+        blocks.remove(0);
+        blocks.push(StoredBlock {
+            cid: cid.to_string(),
+            data,
+            links: vec![],
+        });
+
+        assert!(validate_dag(blocks).is_err());
+    }
+
+    #[tokio::test]
+    pub async fn test_dag_no_blocks() {
+        assert!(validate_dag(vec![]).is_err());
     }
 }

--- a/local-storage/src/block.rs
+++ b/local-storage/src/block.rs
@@ -48,13 +48,15 @@ pub fn validate_dag(stored_blocks: Vec<StoredBlock>) -> Result<()> {
     for block in blocks.iter() {
         block.validate()?;
     }
-    // If there is only one block and it is validate....then ok
+    // If there is only one block, and it is valid, then assume it's valid on its own
     if blocks.len() == 1 {
         return Ok(());
     }
-    // Now find the root
+    // Otherwise find the root
     let root = blocks.iter().find(|b| !b.links().is_empty());
     if let Some(root) = root {
+        // The block's validate function already tells us if the CID's hash matches the root links
+        // So now we just need compare the deduplicated sets of CIDs from the child blocks and the root links
         let child_cids = blocks
             .iter()
             .filter(|b| b.links().is_empty())
@@ -65,7 +67,6 @@ pub fn validate_dag(stored_blocks: Vec<StoredBlock>) -> Result<()> {
             .iter()
             .map(|l| l.to_string())
             .collect::<HashSet<String>>();
-
         if child_cids != linked_cids {
             bail!("Links do not match blocks");
         }

--- a/local-storage/src/block.rs
+++ b/local-storage/src/block.rs
@@ -1,0 +1,109 @@
+use anyhow::Result;
+use bytes::Bytes;
+use cid::Cid;
+use iroh_unixfs::Block;
+use std::str::FromStr;
+
+#[derive(Debug, PartialEq)]
+pub struct StoredBlock {
+    pub cid: String,
+    pub data: Vec<u8>,
+    pub links: Vec<String>,
+}
+
+impl StoredBlock {
+    pub fn validate(&self) -> Result<()> {
+        let real_cid = Cid::from_str(&self.cid)?;
+        let real_links = self
+            .links
+            .iter()
+            .map(|l| Cid::from_str(l).unwrap())
+            .collect::<Vec<Cid>>();
+        let real_data = Bytes::from(self.data.clone());
+        // For now we'll just piggy back on the validate logic built
+        // into n0/beetle:unixfs::Block
+        let block = Block::new(real_cid, real_data, real_links);
+        block.validate()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use anyhow::anyhow;
+    use futures::TryStreamExt;
+    use iroh_unixfs::builder::{File, FileBuilder};
+    use libipld::error::InvalidMultihash;
+
+    async fn generate_stored_blocks(data: Vec<u8>) -> Result<Vec<StoredBlock>> {
+        let file: File = FileBuilder::new()
+            .content_bytes(data)
+            .name("testfile")
+            .fixed_chunker(20)
+            .build()
+            .await?;
+        let blocks: Vec<_> = file.encode().await?.try_collect().await?;
+        let mut stored_blocks = vec![];
+
+        blocks.iter().for_each(|b| {
+            let links = b
+                .links()
+                .iter()
+                .map(|c| c.to_string())
+                .collect::<Vec<String>>();
+            let stored = StoredBlock {
+                cid: b.cid().to_string(),
+                data: b.data().to_vec(),
+                links,
+            };
+
+            stored_blocks.push(stored);
+        });
+
+        Ok(stored_blocks)
+    }
+
+    #[tokio::test]
+    pub async fn test_valid_block_no_links() {
+        let blocks = generate_stored_blocks(vec![0; 10]).await.unwrap();
+        let stored_block = blocks.first().unwrap();
+
+        assert!(stored_block.validate().is_ok());
+    }
+
+    #[tokio::test]
+    pub async fn test_invalid_block_no_links() {
+        let mut blocks = generate_stored_blocks(vec![0; 10]).await.unwrap();
+        let mut stored_block = blocks.pop().unwrap();
+        stored_block.data.extend(b"corruption");
+
+        assert_eq!(
+            stored_block.validate().unwrap_err().to_string(),
+            anyhow!(InvalidMultihash(stored_block.data)).to_string(),
+        );
+    }
+
+    #[tokio::test]
+    pub async fn test_valid_block_with_links() {
+        let blocks = generate_stored_blocks(vec![15; 50]).await.unwrap();
+        let stored_block = blocks.last().unwrap();
+
+        assert!(stored_block.links.len() > 0);
+        assert!(stored_block.validate().is_ok());
+    }
+
+    #[tokio::test]
+    pub async fn test_valid_block_with_invalid_links() {
+        let mut blocks = generate_stored_blocks(vec![15; 50]).await.unwrap();
+        let stored_block = blocks.last_mut().unwrap();
+
+        stored_block.links.pop();
+
+        assert!(stored_block.links.len() > 0);
+        assert_eq!(
+            stored_block.validate().unwrap_err().to_string(),
+            "links do not match"
+        );
+    }
+}

--- a/local-storage/src/block.rs
+++ b/local-storage/src/block.rs
@@ -79,11 +79,9 @@ pub fn validate_dag(stored_blocks: Vec<StoredBlock>) -> Result<()> {
 mod tests {
     use super::*;
 
-    use anyhow::anyhow;
     use cid::multihash::MultihashDigest;
     use futures::TryStreamExt;
     use iroh_unixfs::builder::{File, FileBuilder};
-    use libipld::error::InvalidMultihash;
     use rand::{thread_rng, RngCore};
 
     async fn generate_stored_blocks(num_blocks: u8) -> Result<Vec<StoredBlock>> {
@@ -136,7 +134,7 @@ mod tests {
 
         assert_eq!(
             stored_block.validate().unwrap_err().to_string(),
-            anyhow!(InvalidMultihash(stored_block.data)).to_string(),
+            "Hash of data does not match the CID."
         );
     }
 
@@ -196,7 +194,10 @@ mod tests {
 
         blocks.remove(0);
 
-        assert!(validate_dag(blocks).is_err());
+        assert_eq!(
+            validate_dag(blocks).unwrap_err().to_string(),
+            "Links do not match blocks"
+        );
     }
 
     #[tokio::test]
@@ -205,7 +206,10 @@ mod tests {
 
         blocks.pop();
 
-        assert!(validate_dag(blocks).is_err());
+        assert_eq!(
+            validate_dag(blocks).unwrap_err().to_string(),
+            "No root found"
+        );
     }
 
     #[tokio::test]
@@ -221,7 +225,10 @@ mod tests {
             links: vec![],
         });
 
-        assert!(validate_dag(blocks).is_err());
+        assert_eq!(
+            validate_dag(blocks).unwrap_err().to_string(),
+            "Links do not match blocks"
+        );
     }
 
     #[tokio::test]
@@ -239,11 +246,17 @@ mod tests {
             links: vec![],
         });
 
-        assert!(validate_dag(blocks).is_err());
+        assert_eq!(
+            validate_dag(blocks).unwrap_err().to_string(),
+            "Links do not match blocks"
+        );
     }
 
     #[tokio::test]
     pub async fn test_dag_no_blocks() {
-        assert!(validate_dag(vec![]).is_err());
+        assert_eq!(
+            validate_dag(vec![]).unwrap_err().to_string(),
+            "No blocks found in dag"
+        );
     }
 }

--- a/local-storage/src/lib.rs
+++ b/local-storage/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod block;
 pub mod error;
 pub mod provider;
 pub mod storage;

--- a/local-storage/src/lib.rs
+++ b/local-storage/src/lib.rs
@@ -2,3 +2,4 @@ pub mod block;
 pub mod error;
 pub mod provider;
 pub mod storage;
+mod util;

--- a/local-storage/src/provider.rs
+++ b/local-storage/src/provider.rs
@@ -1,4 +1,4 @@
-use crate::{error::StorageError, storage::StoredBlock};
+use crate::{block::StoredBlock, error::StorageError};
 
 use anyhow::{bail, Result};
 use rusqlite::Connection;

--- a/local-storage/src/storage.rs
+++ b/local-storage/src/storage.rs
@@ -1,6 +1,7 @@
 use crate::error::StorageError;
 use crate::provider::StorageProvider;
 
+use crate::block::StoredBlock;
 use anyhow::{bail, Result};
 use futures::TryStreamExt;
 use iroh_unixfs::builder::{File, FileBuilder};
@@ -106,13 +107,6 @@ impl Storage {
     pub fn list_available_dags(&self) -> Result<Vec<String>> {
         self.provider.list_available_dags()
     }
-}
-
-#[derive(Debug, PartialEq)]
-pub struct StoredBlock {
-    pub cid: String,
-    pub data: Vec<u8>,
-    pub links: Vec<String>,
 }
 
 #[cfg(test)]

--- a/local-storage/src/util.rs
+++ b/local-storage/src/util.rs
@@ -1,0 +1,87 @@
+use super::block::StoredBlock;
+use anyhow::{bail, Result};
+
+pub(crate) fn verify_dag(blocks: &[StoredBlock]) -> Result<()> {
+    use std::collections::{HashMap, HashSet, VecDeque};
+
+    // Map of CID -> linked (1) or not (ud)
+    let mut indegree: HashMap<&str, usize> = HashMap::new();
+    // List of root blocks
+    let mut queue = VecDeque::new();
+    let mut visited = HashSet::<&str>::new();
+    let mut mp: HashMap<&str, &StoredBlock> = HashMap::new();
+    let mut result = vec![];
+
+    blocks.iter().for_each(|block| {
+        indegree.insert(&block.cid, 0);
+        mp.insert(&block.cid, block);
+    });
+
+    // compute in-degree
+    for block in blocks.iter() {
+        // For each block, examine which CIDs are linked to
+        for link in block.links.iter() {
+            let link_cid = link.as_str();
+            // If the linked CID exists in our collection of blocks, set that CID's degree
+            if let Some(degree) = indegree.get_mut(&link_cid) {
+                *degree = 1;
+            } else {
+                bail!("Links do not match blocks");
+            }
+        }
+    }
+
+    // Find roots
+    blocks.iter().for_each(|block| {
+        if let Some(degree) = indegree.get(&block.cid.as_str()) {
+            // For each block, if it is *not* linked, and has not been visited, put in root queue
+            // visited has not been touched at this point, so does that check do anything?
+            if degree == &0 && !visited.contains(&block.cid.as_str()) {
+                queue.push_back(block);
+            }
+        }
+    });
+
+    // DAG should have exactly 1 root
+    if queue.len() != 1 {
+        bail!("No root found");
+    }
+
+    // While there are roots to examine
+    while !queue.is_empty() {
+        // this is a safe unwrap as the queue is not empty
+        let node: &StoredBlock = queue.pop_front().unwrap();
+        // ignore a visite node
+        if visited.contains(&node.cid.as_str()) {
+            continue;
+        }
+
+        // validate the root node
+        node.validate()?;
+
+        // collect root node in result
+        result.push(node);
+        // mark root node as visited
+        visited.insert(&node.cid);
+        // walk the root links
+        for link in node.links.iter() {
+            let cid = link.as_str();
+            // Grab the degree of the linked cid
+            if let Some(degree) = indegree.get_mut(&cid) {
+                // mark the degree as seen
+                *degree -= 1;
+                // push a block with in-degree 0 to the queue
+                if *degree == 0 {
+                    // safe unwrap
+                    let block = *mp.get(&cid).unwrap();
+                    queue.push_back(block);
+                }
+            }
+        }
+    }
+
+    if result.len() != blocks.len() {
+        bail!("graph is cyclic");
+    }
+    Ok(())
+}


### PR DESCRIPTION
### Added

- Added `validate` for `StoredBlock` to leverage the validation functionality built into `beetle::iroh_unixfs::Block`.
- Added `local_storage::block::validate_dag` which determines if a list of `StoredBlock`s constitute a complete and valid DAG.

### Changed

- Moved `StoredBlock` and associated implementation/tests out of the `storage` mod into a `block` mod within `local-storage`.
