### PR TITLE
Upgrade address parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - Added `mtu` config parameter to `myceli`.
 - Renamed `app-api-cli` to `controller`.
+- Fixed `controller` to resolve addresses
+- Standardize default addresses on `0.0.0.0`
+- Added configurable listen address to `hyphae`
+- Added configurable listen address to `controller`
 
 ## [0.6] - 2023-04-04
 

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -1,18 +1,20 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::{arg, Parser};
 use messages::{ApplicationAPI, Message, MessageChunker, SimpleChunker};
-use std::net::SocketAddr;
+use std::net::{SocketAddr, ToSocketAddrs};
 use std::time::Duration;
 use tokio::net::UdpSocket;
 use tokio::time::sleep;
 
 #[derive(Parser, Debug, Clone)]
 #[clap(version, long_about = None, propagate_version = true)]
-#[clap(about = "Control an IPFS instance")]
+#[clap(about = "Control a Myceli instance")]
 pub struct Cli {
     instance_addr: String,
     #[arg(short, long)]
-    listen: bool,
+    listen_mode: bool,
+    #[arg(short, long, default_value = "127.0.0.1:9090")]
+    bind_address: String,
     #[clap(subcommand)]
     command: ApplicationAPI,
 }
@@ -23,14 +25,22 @@ impl Cli {
         let command = Message::ApplicationAPI(self.command.clone());
         let cmd_str = serde_json::to_string(&command)?;
         println!("Transmitting: {}", &cmd_str);
-        let target_address: SocketAddr = self.instance_addr.parse()?;
-        let bind_address: SocketAddr = "127.0.0.1:0".parse()?;
+        let target_address = self
+            .instance_addr
+            .to_socket_addrs()?
+            .next()
+            .ok_or(anyhow!("Error parsing target address"))?;
+        let bind_address: SocketAddr = self
+            .bind_address
+            .to_socket_addrs()?
+            .next()
+            .ok_or(anyhow!("Error parsing listen address"))?;
         let socket = UdpSocket::bind(&bind_address).await?;
         for chunks in chunker.chunk(command).unwrap() {
             socket.send_to(&chunks, target_address).await?;
         }
 
-        if self.listen {
+        if self.listen_mode {
             loop {
                 let mut buf = vec![0; 1024];
                 if socket.recv(&mut buf).await.is_ok() {

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -13,7 +13,7 @@ pub struct Cli {
     instance_addr: String,
     #[arg(short, long)]
     listen_mode: bool,
-    #[arg(short, long, default_value = "127.0.0.1:9090")]
+    #[arg(short, long, default_value = "0.0.0.0:8090")]
     bind_address: String,
     #[clap(subcommand)]
     command: ApplicationAPI,

--- a/hyphae/src/config.rs
+++ b/hyphae/src/config.rs
@@ -8,18 +8,20 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
     pub myceli_address: String,
+    pub listen_to_myceli_address: String,
     pub kubo_address: String,
     pub sync_interval: u64,
-    pub mtu: u16,
+    pub myceli_mtu: u16,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Config {
-            myceli_address: "127.0.0.1:8080".to_string(),
-            kubo_address: "127.0.0.1:5001".to_string(),
+            myceli_address: "0.0.0.0:8080".to_string(),
+            listen_to_myceli_address: "0.0.0.0:8090".to_string(),
+            kubo_address: "0.0.0.0:5001".to_string(),
             sync_interval: 10_000,
-            mtu: 60,
+            myceli_mtu: 60,
         }
     }
 }

--- a/hyphae/src/main.rs
+++ b/hyphae/src/main.rs
@@ -95,7 +95,12 @@ fn main() -> Result<()> {
     info!("Connecting to kubo@{}", cfg.kubo_address);
 
     let kubo = KuboApi::new(&cfg.kubo_address);
-    let myceli = MyceliApi::new(&cfg.myceli_address, cfg.mtu);
+    let myceli = MyceliApi::new(
+        &cfg.myceli_address,
+        &cfg.listen_to_myceli_address,
+        cfg.myceli_mtu,
+    )
+    .expect("Failed to create MyceliAPi");
 
     loop {
         if kubo.check_alive() && myceli.check_alive() {

--- a/myceli/src/config.rs
+++ b/myceli/src/config.rs
@@ -48,7 +48,7 @@ impl std::default::Default for MyceliConfig {
     fn default() -> Self {
         Self {
             // Default listening address
-            listen_address: "127.0.0.1:8080".to_string(),
+            listen_address: "0.0.0.0:8080".to_string(),
             // Default retry timeout of 120_000 ms = 120 s = 2 minutes
             retry_timeout_duration: 120_000,
             // Default storage dir

--- a/myceli/tests/utils/mod.rs
+++ b/myceli/tests/utils/mod.rs
@@ -72,7 +72,7 @@ impl TestController {
     pub fn new() -> Self {
         let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
         socket
-            .set_read_timeout(Some(Duration::from_millis(10)))
+            .set_read_timeout(Some(Duration::from_millis(50)))
             .unwrap();
         let chunker = SimpleChunker::new(60);
         TestController { socket, chunker }
@@ -102,7 +102,7 @@ impl TestController {
             }
             sleep(Duration::from_millis(10));
             tries += 1;
-            if tries > 10 {
+            if tries > 20 {
                 bail!("Listen tries exceeded");
             }
         }


### PR DESCRIPTION
- Fix `controller` to resolve addresses
- Standardize default addresses on `0.0.0.0`
- Added configurable listen address to `hyphae`
- Added configurable listen address to `controller`