### PR TITLE
UDP Transport Chunk Requesting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +424,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "car-utility"
 version = "0.1.0"
 dependencies = [
@@ -428,6 +443,28 @@ dependencies = [
  "iroh-car",
  "iroh-resolver",
  "tokio",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1024,6 +1061,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1319,12 @@ name = "gimli"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
@@ -2551,6 +2603,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mini-moka"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cafc5ec7807288595f9c20c86e6ce6d262b722f61e0547fe7e6e6e6451b58d5"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "triomphe",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3491,6 +3558,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quanta"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3988,6 +4066,9 @@ name = "semver"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -4182,6 +4263,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4298,6 +4394,12 @@ dependencies = [
  "rayon",
  "winapi",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"
@@ -4761,12 +4863,19 @@ dependencies = [
  "anyhow",
  "cid 0.10.1",
  "messages",
+ "mini-moka",
  "parity-scale-codec",
  "parity-scale-codec-derive",
  "rand 0.8.5",
  "serde",
  "tracing",
 ]
+
+[[package]]
+name = "triomphe"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ee9bd9239c339d714d657fac840c6d2a4f9c45f4f9ec7b0975113458be78db"
 
 [[package]]
 name = "trust-dns-proto"

--- a/transports/Cargo.toml
+++ b/transports/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 anyhow = "1"
 cid = { version = "0.10" }
 messages = { path = "../messages" }
+mini-moka = "0.10.0"
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive", "std"] }
 parity-scale-codec-derive = "3.1.3"
 rand = "0.8.5"

--- a/transports/src/udp_chunking.rs
+++ b/transports/src/udp_chunking.rs
@@ -1,10 +1,28 @@
 use anyhow::{bail, Result};
 use messages::Message;
+use mini_moka::sync::Cache;
 use parity_scale_codec::{Decode, Encode};
 use parity_scale_codec_derive::{Decode as ParityDecode, Encode as ParityEncode};
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use crate::chunking::MessageContainer;
+
+#[derive(Clone, Debug, ParityDecode, ParityEncode, PartialEq)]
+pub enum UnchunkResult {
+    Message(Message),
+    Missing(MissingChunks),
+}
+
+#[derive(Clone, Debug, ParityDecode, ParityEncode)]
+pub enum SimpleMsg {
+    Chunk(SimpleChunk),
+    Missing(MissingChunks),
+}
+
+// List of (message_id, sequence_id) tuples for identifying missing message chunks
+#[derive(Clone, Debug, ParityDecode, ParityEncode, PartialEq)]
+pub struct MissingChunks(pub Vec<(u16, u16)>);
 
 #[derive(Clone, Debug, ParityDecode, ParityEncode)]
 pub struct SimpleChunk {
@@ -19,47 +37,58 @@ pub struct SimpleChunk {
 }
 
 // This const is derived from the size of the above struct when encoded with SCALE
-// and verified using a test below. It appears to consistently be seven,
+// and verified using a test below. It appears to consistently around eight,
 // except when data is fairly small
-const CHUNK_OVERHEAD: u16 = 7;
+const CHUNK_OVERHEAD: u16 = 8;
 
 pub struct SimpleChunker {
     // Max message size
     mtu: u16,
     // Map of message IDs to maps of sequence numbers and message chunks
-    // { message_id: { sequence_id: data }}
-    recv_buffer: BTreeMap<u16, BTreeMap<u16, SimpleChunk>>,
+    // { message_id: { sequence_id: chunk }}
+    recv_cache: Cache<u16, BTreeMap<u16, SimpleChunk>>,
+    // Cache of sent message chunks
+    // { message_id: { sequence_id: chunk }}
+    sent_cache: Cache<u16, BTreeMap<u16, SimpleChunk>>,
     // Last received message_id to optimize reassembly searching
     last_recv_msg_id: u16,
 }
 
 impl SimpleChunker {
     pub fn new(mtu: u16) -> Self {
+        let sent_cache = Cache::builder()
+            .initial_capacity(500)
+            .time_to_idle(Duration::from_secs(60))
+            .build();
+        let recv_cache = Cache::builder()
+            .initial_capacity(500)
+            .time_to_idle(Duration::from_secs(60))
+            .build();
         Self {
             mtu,
-            recv_buffer: BTreeMap::<u16, BTreeMap<u16, SimpleChunk>>::new(),
+            sent_cache,
+            recv_cache,
             last_recv_msg_id: 0,
         }
     }
 
     fn recv_chunk(&mut self, chunk: SimpleChunk) -> Result<()> {
         self.last_recv_msg_id = chunk.message_id;
-        if let Some(msg_map) = self.recv_buffer.get_mut(&chunk.message_id) {
+        let msg_map = if let Some(mut msg_map) = self.recv_cache.get(&self.last_recv_msg_id) {
             msg_map.insert(chunk.sequence_number, chunk);
+            msg_map
         } else {
             let mut msg_map: BTreeMap<u16, SimpleChunk> = BTreeMap::new();
             msg_map.insert(chunk.sequence_number, chunk);
-            self.recv_buffer.insert(self.last_recv_msg_id, msg_map);
-        }
+            msg_map
+        };
+        self.recv_cache.insert(self.last_recv_msg_id, msg_map);
 
         Ok(())
     }
 
-    fn attempt_msg_assembly(&mut self) -> Result<Option<Message>> {
-        // TODO: This needs to be expanded beyond just assembling off the last received message id
-        // TODO: Data needs to be removed from the map once the message is assembled correctly
-        // TODO: Stale data in the map needs to be cleaned up periodically
-        if let Some(msg_map) = self.recv_buffer.get(&self.last_recv_msg_id) {
+    fn actually_assemble_msg(&mut self, msg_id: u16) -> Result<Option<UnchunkResult>> {
+        if let Some(msg_map) = self.recv_cache.get(&msg_id) {
             // The BTreeMap docs tell us that into_values will be an iter sorted by key
             // In this case the key is the sequence_number, so in a complete set of chunks
             // that means the last item in the iter (or now vec) should be the "final chunk"
@@ -73,12 +102,36 @@ impl SimpleChunker {
                 {
                     // If all those checks pass, then we *should* have all the chunks in order
                     // Now we attempt to assemble the message
-                    return Ok(Some(SimpleChunker::msg_unchunk(&chunks)?));
+                    match SimpleChunker::msg_unchunk(&chunks) {
+                        Ok(msg) => {
+                            // If the assembly passes then remove the message's associated chunks`
+                            self.recv_cache.invalidate(&msg_id);
+                            return Ok(Some(UnchunkResult::Message(msg)));
+                        }
+                        Err(e) => bail!(e),
+                    }
                 }
             }
         }
 
         Ok(None)
+    }
+
+    fn attempt_msg_assembly(&mut self) -> Result<Option<UnchunkResult>> {
+        match self.actually_assemble_msg(self.last_recv_msg_id) {
+            Ok(None) => {
+                // If the last received msg can't be assembled, then attempt
+                // to assemble other messages waiting in the cache
+                for entry in self.recv_cache.clone().iter() {
+                    match self.actually_assemble_msg(*entry.key()) {
+                        Ok(None) => continue,
+                        other => return other,
+                    }
+                }
+                return Ok(None);
+            }
+            other => other,
+        }
     }
 
     pub fn msg_unchunk(data: &[&SimpleChunk]) -> Result<Message> {
@@ -87,6 +140,38 @@ impl SimpleChunker {
         let mut databuf = &all_data[..all_data.len()];
         let container = MessageContainer::from_bytes(&mut databuf)?;
         Ok(container.message)
+    }
+
+    pub fn find_missing_chunks_map(&self) -> Result<Vec<(u16, u16)>> {
+        let mut missing_chunks: Vec<(u16, u16)> = vec![];
+
+        for entry in self.recv_cache.iter() {
+            let msg_id = entry.key();
+            let chunks = entry.value().values().collect::<Vec<&SimpleChunk>>();
+            let mut previous_seq_number = None;
+            let mut found_last = false;
+
+            for c in chunks {
+                let prev_seq_num = if let Some(prev_seq_num) = previous_seq_number {
+                    prev_seq_num + 1
+                } else if c.sequence_number > 0 {
+                    0
+                } else {
+                    c.sequence_number
+                };
+                for missing in (prev_seq_num)..c.sequence_number {
+                    missing_chunks.push((*msg_id, missing));
+                }
+                previous_seq_number = Some(c.sequence_number);
+                found_last = c.final_chunk;
+            }
+
+            if !found_last {
+                missing_chunks.push((*msg_id, previous_seq_number.unwrap() + 1));
+            }
+        }
+
+        Ok(missing_chunks)
     }
 
     pub fn chunk(&self, message: Message) -> Result<Vec<Vec<u8>>> {
@@ -114,19 +199,58 @@ impl SimpleChunker {
         if let Some(mut last_chunk) = chunks.last_mut() {
             last_chunk.final_chunk = true;
         }
+        let mut msg_map = BTreeMap::new();
+        for c in chunks.iter() {
+            msg_map.insert(c.sequence_number, c.clone());
+        }
+        if !msg_map.is_empty() {
+            self.sent_cache.insert(msg_id, msg_map);
+        }
         // Encode all the chunks
-        Ok(chunks.iter().map(|c| c.encode()).collect::<Vec<Vec<u8>>>())
+        Ok(chunks
+            .iter()
+            .map(|c| SimpleMsg::Chunk(c.clone()).encode())
+            .collect::<Vec<Vec<u8>>>())
     }
 
-    pub fn unchunk(&mut self, data: &[u8]) -> Result<Option<Message>> {
+    pub fn unchunk(&mut self, data: &[u8]) -> Result<Option<UnchunkResult>> {
         let mut databuf = &data[..data.len()];
-        match SimpleChunk::decode(&mut databuf) {
-            Ok(chunk) => {
+        match SimpleMsg::decode(&mut databuf) {
+            Ok(SimpleMsg::Chunk(chunk)) => {
                 self.recv_chunk(chunk)?;
-                Ok(self.attempt_msg_assembly()?)
+                return Ok(self.attempt_msg_assembly()?);
             }
-            Err(e) => bail!("Failed to decode chunk {e:?}"),
+            Ok(SimpleMsg::Missing(missing)) => {
+                return Ok(Some(UnchunkResult::Missing(missing)));
+            }
+            Err(e) => bail!("Failed to decode {e:?}"),
         }
+    }
+
+    pub fn get_prev_sent_chunks(&self, chunk_map: Vec<(u16, u16)>) -> Result<Vec<Vec<u8>>> {
+        let mut found_chunks = vec![];
+
+        for (msg_id, chunk_seq) in chunk_map {
+            if let Some(sent_chunks) = self.sent_cache.get(&msg_id) {
+                if let Some(found) = sent_chunks.get(&chunk_seq) {
+                    found_chunks.push(SimpleMsg::Chunk(found.clone()).encode());
+                }
+            }
+        }
+
+        Ok(found_chunks)
+    }
+
+    pub fn find_missing_chunks(&self) -> Result<Vec<Vec<u8>>> {
+        let mut msgs = vec![];
+        let missing_map = self.find_missing_chunks_map()?;
+        // Overhead is 4 + 2 per missing
+        let range_allowed_by_mtu = ((self.mtu - 4) / 4) - 1;
+        for chunk in missing_map.chunks(range_allowed_by_mtu.into()) {
+            let msg_encode = SimpleMsg::Missing(MissingChunks(chunk.to_vec())).encode();
+            msgs.push(msg_encode);
+        }
+        Ok(msgs)
     }
 }
 
@@ -137,24 +261,6 @@ mod tests {
     use messages::ApplicationAPI;
     use rand::seq::SliceRandom;
     use rand::thread_rng;
-
-    #[test]
-    pub fn test_chunk_overhead_against_const() {
-        let data_sizes = [600, 2500, 5000, 10240];
-        for size in data_sizes {
-            let chunk = SimpleChunk {
-                message_id: size,
-                sequence_number: size,
-                final_chunk: true,
-                data: vec![80; usize::from(size)],
-            };
-            let chunk_encoded_size = chunk.encoded_size();
-            assert_eq!(
-                chunk_encoded_size - usize::from(size),
-                usize::from(CHUNK_OVERHEAD)
-            );
-        }
-    }
 
     #[test]
     pub fn test_chunking_under_various_mtus() {
@@ -188,8 +294,13 @@ mod tests {
 
         assert_eq!(chunks.len(), 1);
 
-        let unchunked_message = chunker.unchunk(chunks.first().unwrap()).unwrap().unwrap();
-        assert_eq!(msg, unchunked_message);
+        if let UnchunkResult::Message(unchunked_message) =
+            chunker.unchunk(chunks.first().unwrap()).unwrap().unwrap()
+        {
+            assert_eq!(msg, unchunked_message);
+        } else {
+            panic!("Failed to find correct message");
+        }
     }
 
     // Testing scenario where a single message is broken into multiple chunks in sequential order
@@ -209,8 +320,13 @@ mod tests {
             let unchunk = chunker.unchunk(&chunk).unwrap();
             assert!(unchunk.is_none());
         }
-        let unchunked_msg = chunker.unchunk(&last_chunk).unwrap().unwrap();
-        assert_eq!(unchunked_msg, msg);
+        if let UnchunkResult::Message(unchunked_msg) =
+            chunker.unchunk(&last_chunk).unwrap().unwrap()
+        {
+            assert_eq!(unchunked_msg, msg);
+        } else {
+            panic!("Failed to find correct message");
+        }
     }
 
     // Testing scenario where a single message is broken into multiple chunks in random order
@@ -234,8 +350,13 @@ mod tests {
             let unchunk = chunker.unchunk(&chunk).unwrap();
             assert!(unchunk.is_none());
         }
-        let unchunked_msg = chunker.unchunk(&last_chunk).unwrap().unwrap();
-        assert_eq!(unchunked_msg, msg);
+        if let UnchunkResult::Message(unchunked_msg) =
+            chunker.unchunk(&last_chunk).unwrap().unwrap()
+        {
+            assert_eq!(unchunked_msg, msg);
+        } else {
+            panic!("Failed to find correct message");
+        }
     }
 
     // Testing scenario where two messages are broken into single chunks in sequential order
@@ -245,23 +366,27 @@ mod tests {
             cids: vec!["hello I am a CID".to_string()],
         });
         let msg_two = Message::ApplicationAPI(ApplicationAPI::AvailableBlocks {
-            cids: vec!["hello I am a different CID".to_string()],
+            cids: vec!["hello I am a diff CID".to_string()],
         });
         let mut chunker = SimpleChunker::new(60);
         let msg_one_chunks = chunker.chunk(msg_one.clone()).unwrap();
         let msg_two_chunks = chunker.chunk(msg_two.clone()).unwrap();
 
-        let unchunked_message = chunker
-            .unchunk(msg_one_chunks.first().unwrap())
-            .unwrap()
-            .unwrap();
-        assert_eq!(msg_one, unchunked_message);
+        if let Some(UnchunkResult::Message(unchunked_message)) =
+            chunker.unchunk(msg_one_chunks.first().unwrap()).unwrap()
+        {
+            assert_eq!(msg_one, unchunked_message);
+        } else {
+            panic!("Failed to decode message");
+        }
 
-        let unchunked_message = chunker
-            .unchunk(msg_two_chunks.first().unwrap())
-            .unwrap()
-            .unwrap();
-        assert_eq!(msg_two, unchunked_message);
+        if let Some(UnchunkResult::Message(unchunked_message)) =
+            chunker.unchunk(msg_two_chunks.first().unwrap()).unwrap()
+        {
+            assert_eq!(msg_two, unchunked_message);
+        } else {
+            panic!("Failed to decode message");
+        }
     }
 
     // Testing scenario where two messages are broken into multiple chunks in sequential order
@@ -284,11 +409,11 @@ mod tests {
         let mut found_msgs = 0;
         for chunk in chunks {
             match chunker.unchunk(&chunk) {
-                Ok(Some(msg)) => {
+                Ok(Some(UnchunkResult::Message(msg))) => {
                     assert!([&msg_one, &msg_two].contains(&&msg));
                     found_msgs += 1;
                 }
-                Ok(None) => {}
+                Ok(other) => {}
                 Err(_) => {}
             }
         }
@@ -317,11 +442,11 @@ mod tests {
         let mut found_msgs = 0;
         for chunk in chunks {
             match chunker.unchunk(&chunk) {
-                Ok(Some(msg)) => {
+                Ok(Some(UnchunkResult::Message(msg))) => {
                     assert!([&msg_one, &msg_two].contains(&&msg));
                     found_msgs += 1;
                 }
-                Ok(None) => {}
+                Ok(other) => {}
                 Err(_) => {}
             }
         }
@@ -356,11 +481,11 @@ mod tests {
         let mut found_msgs = 0;
         for chunk in chunks {
             match chunker.unchunk(&chunk) {
-                Ok(Some(msg)) => {
+                Ok(Some(UnchunkResult::Message(msg))) => {
                     assert!(msgs.contains(&msg));
                     found_msgs += 1;
                 }
-                Ok(None) => {}
+                Ok(other) => {}
                 Err(_) => {}
             }
         }
@@ -388,5 +513,244 @@ mod tests {
         }
         let unchunked_msg = chunker.unchunk(&last_chunk);
         assert!(unchunked_msg.is_err());
+    }
+
+    // Testing scenario where single missing chunk is identified
+    #[test]
+    pub fn test_find_single_missing_chunk() {
+        let msg = Message::ApplicationAPI(ApplicationAPI::AvailableBlocks {
+            cids: vec!["hello i am a CID".to_string(); 10],
+        });
+        let mut chunker = SimpleChunker::new(60);
+        let mut chunks = chunker.chunk(msg).unwrap();
+
+        assert_eq!(chunks.len(), 4);
+
+        let missing_chunk = chunks.remove(2);
+        let mut databuf = &missing_chunk[..missing_chunk.len()];
+        let missing_chunk = if let Ok(SimpleMsg::Chunk(chunk)) = SimpleMsg::decode(&mut databuf) {
+            chunk
+        } else {
+            panic!("decode removed chunk failed");
+        };
+
+        for chunk in chunks {
+            let unchunk = chunker.unchunk(&chunk).unwrap();
+            assert!(unchunk.is_none());
+        }
+
+        let missing_chunks = chunker.find_missing_chunks_map().unwrap();
+        let mut missing_map = vec![(missing_chunk.message_id, missing_chunk.sequence_number)];
+
+        assert_eq!(missing_chunks, missing_map);
+    }
+
+    // Testing scenario where single missing chunk is identified
+    #[test]
+    pub fn test_find_first_missing_chunk() {
+        let msg = Message::ApplicationAPI(ApplicationAPI::AvailableBlocks {
+            cids: vec!["hello i am a CID".to_string(); 10],
+        });
+        let mut chunker = SimpleChunker::new(60);
+        let mut chunks = chunker.chunk(msg).unwrap();
+
+        assert_eq!(chunks.len(), 4);
+
+        let missing_chunk = chunks.remove(0);
+        let mut databuf = &missing_chunk[..missing_chunk.len()];
+        let missing_chunk = if let Ok(SimpleMsg::Chunk(chunk)) = SimpleMsg::decode(&mut databuf) {
+            chunk
+        } else {
+            panic!("decode removed chunk failed");
+        };
+
+        for chunk in chunks {
+            let unchunk = chunker.unchunk(&chunk).unwrap();
+            assert!(unchunk.is_none());
+        }
+
+        let missing_chunks = chunker.find_missing_chunks_map().unwrap();
+        let mut missing_map = vec![(missing_chunk.message_id, missing_chunk.sequence_number)];
+
+        assert_eq!(missing_chunks, missing_map);
+    }
+
+    // Testing scenario where multiple missing chunks are identified
+    #[test]
+    pub fn test_find_multiple_missing_chunks() {
+        let msg = Message::ApplicationAPI(ApplicationAPI::AvailableBlocks {
+            cids: vec!["hello i am a CID".to_string(); 100],
+        });
+        let mut chunker = SimpleChunker::new(60);
+        let mut chunks = chunker.chunk(msg).unwrap();
+
+        let missing_chunk = chunks.remove(2);
+        let mut databuf = &missing_chunk[..missing_chunk.len()];
+        let missing_chunk = if let Ok(SimpleMsg::Chunk(chunk)) = SimpleMsg::decode(&mut databuf) {
+            chunk
+        } else {
+            panic!("decode removed chunk failed");
+        };
+
+        // Remove a few more chunks for fun
+        chunks.remove(15);
+        chunks.remove(15);
+        chunks.remove(25);
+
+        for chunk in chunks {
+            let unchunk = chunker.unchunk(&chunk).unwrap();
+            assert!(unchunk.is_none());
+        }
+
+        let missing_chunks = chunker.find_missing_chunks_map().unwrap();
+        let mut missing_map = vec![
+            (missing_chunk.message_id, 2),
+            (missing_chunk.message_id, 16),
+            (missing_chunk.message_id, 17),
+            (missing_chunk.message_id, 28),
+        ];
+
+        assert_eq!(missing_chunks, missing_map);
+    }
+
+    // Testing scenario where missing last chunk is identified
+    #[test]
+    pub fn test_find_missing_last_chunk() {
+        let msg = Message::ApplicationAPI(ApplicationAPI::AvailableBlocks {
+            cids: vec!["hello i am a CID".to_string(); 100],
+        });
+        let mut chunker = SimpleChunker::new(60);
+        let mut chunks = chunker.chunk(msg).unwrap();
+
+        let missing_chunk = chunks.pop().unwrap();
+        let mut databuf = &missing_chunk[..missing_chunk.len()];
+        let missing_chunk = if let Ok(SimpleMsg::Chunk(chunk)) = SimpleMsg::decode(&mut databuf) {
+            chunk
+        } else {
+            panic!("decode removed chunk failed");
+        };
+
+        for chunk in chunks {
+            let unchunk = chunker.unchunk(&chunk).unwrap();
+            assert!(unchunk.is_none());
+        }
+
+        let missing_chunks = chunker.find_missing_chunks_map().unwrap();
+        let missing_map = vec![(missing_chunk.message_id, missing_chunk.sequence_number)];
+
+        assert_eq!(missing_chunks, missing_map);
+    }
+
+    // Testing getting missing chunk messages
+    #[test]
+    pub fn test_get_missing_chunk_messages() {
+        let msg = Message::ApplicationAPI(ApplicationAPI::AvailableBlocks {
+            cids: vec!["hello i am a CID".to_string(); 100],
+        });
+        let mut chunker = SimpleChunker::new(60);
+        let mut chunks = chunker.chunk(msg).unwrap();
+
+        let missing_chunk_raw = chunks.remove(2);
+
+        let mut missing_chunks_raw = vec![missing_chunk_raw];
+
+        // Remove a few more chunks for fun
+        missing_chunks_raw.push(chunks.remove(15));
+        missing_chunks_raw.push(chunks.remove(15));
+        missing_chunks_raw.push(chunks.remove(25));
+
+        for chunk in chunks {
+            let unchunk = chunker.unchunk(&chunk).unwrap();
+            assert!(unchunk.is_none());
+        }
+
+        let missing_chunks_messages = chunker
+            .get_prev_sent_chunks(chunker.find_missing_chunks_map().unwrap())
+            .unwrap();
+
+        assert_eq!(missing_chunks_messages, missing_chunks_raw);
+    }
+
+    // Testing getting missing chunk messages size exceeding MTU
+    #[test]
+    pub fn test_get_missing_chunk_messages_respect_mtu() {
+        let msg = Message::ApplicationAPI(ApplicationAPI::AvailableBlocks {
+            cids: vec!["hello i am a CID".to_string(); 200],
+        });
+        let MTU = 60;
+        let mut chunker = SimpleChunker::new(MTU);
+        let mut chunks = chunker.chunk(msg).unwrap();
+
+        let mut missing_chunks_raw: Vec<Vec<u8>> = vec![];
+
+        // Remove a few more chunks for fun
+        missing_chunks_raw.push(chunks.remove(15));
+        missing_chunks_raw.push(chunks.remove(15));
+        missing_chunks_raw.push(chunks.remove(25));
+        missing_chunks_raw.push(chunks.remove(25));
+        missing_chunks_raw.push(chunks.remove(25));
+        missing_chunks_raw.push(chunks.remove(25));
+        missing_chunks_raw.push(chunks.remove(25));
+        missing_chunks_raw.push(chunks.remove(25));
+        missing_chunks_raw.push(chunks.remove(25));
+        missing_chunks_raw.push(chunks.remove(25));
+        missing_chunks_raw.push(chunks.remove(25));
+        missing_chunks_raw.push(chunks.remove(25));
+        missing_chunks_raw.push(chunks.remove(25));
+
+        for chunk in chunks {
+            chunker.unchunk(&chunk).unwrap();
+        }
+
+        let missing_chunk_msgs = chunker.find_missing_chunks().unwrap();
+        for msg in missing_chunk_msgs {
+            assert!(msg.len() <= MTU.into());
+        }
+    }
+
+    // Testing flow of send/receive missing chunks
+    #[test]
+    pub fn test_send_receive_with_missing_chunks() {
+        let msg = Message::ApplicationAPI(ApplicationAPI::AvailableBlocks {
+            cids: vec!["hello i am a CID".to_string(); 100],
+        });
+        let mut sending_chunker = SimpleChunker::new(60);
+        let mut receiving_chunker = SimpleChunker::new(60);
+
+        let mut chunks = sending_chunker.chunk(msg).unwrap();
+
+        let mut missing_chunks_raw = vec![];
+        missing_chunks_raw.push(chunks.remove(2));
+        missing_chunks_raw.push(chunks.remove(15));
+        missing_chunks_raw.push(chunks.remove(15));
+        missing_chunks_raw.push(chunks.remove(25));
+
+        for chunk in chunks {
+            let unchunk = receiving_chunker.unchunk(&chunk).unwrap();
+            assert!(unchunk.is_none());
+        }
+
+        let missing_chunks_map = receiving_chunker.find_missing_chunks().unwrap();
+        let missing_chunks_map = missing_chunks_map.first().unwrap();
+        let mut databuf = &missing_chunks_map[..missing_chunks_map.len()];
+        let missing_chunks = if let Some(UnchunkResult::Missing(missing)) =
+            sending_chunker.unchunk(&mut databuf).unwrap()
+        {
+            sending_chunker.get_prev_sent_chunks(missing.0).unwrap()
+        } else {
+            panic!("Failed to find missing message");
+        };
+
+        let mut found_msgs = 0;
+        for chunk in missing_chunks {
+            match receiving_chunker.unchunk(&chunk) {
+                Ok(Some(UnchunkResult::Message(msg))) => {
+                    found_msgs += 1;
+                }
+                Ok(other) => {}
+                Err(_) => {}
+            }
+        }
+        assert_eq!(found_msgs, 1);
     }
 }

--- a/transports/src/udp_transport.rs
+++ b/transports/src/udp_transport.rs
@@ -2,11 +2,11 @@ use crate::udp_chunking::{SimpleChunker, UnchunkResult};
 use crate::Transport;
 use anyhow::{anyhow, bail, Result};
 use messages::Message;
-use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
+use std::net::{ToSocketAddrs, UdpSocket};
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::Duration;
-use tracing::{debug, error};
+use tracing::{error};
 
 pub struct UdpTransport {
     pub socket: UdpSocket,


### PR DESCRIPTION
This PR adds two interesting pieces of functionality:
- [x] Time-based caching of UDP chunks to prevent stale chunks for eating up all the memory
- [x] Re-requesting specific missing chunks of messages for better reliability over unreliable radio links