### PR TITLE
Fixes before 0.6.4 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - Updated default block size to 256 bytes and generally improved handling of larger files in storage layer.
 - Archived unused `car-utility` and `cpp-transmit-example` projects.
 - Converted all crate dependencies to workspace dependencies, tightened version specificity, narrowed features when possible.
+- Increase default MTU to 512 bytes to accommodate more realistic systems
+- Move functions for fetching all DAG cids & blocks into storage layer
+- Increase default file block size to 100kb for better performance when importing larger files
+- Small revision to testing plan
 
 ## [0.6.3] - 2023-05-04
 

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -18,7 +18,7 @@ pub struct Cli {
 
 impl Cli {
     pub async fn run(&self) -> Result<()> {
-        let transport = UdpTransport::new(&self.bind_address, 60)?;
+        let transport = UdpTransport::new(&self.bind_address, 512)?;
 
         let command = Message::ApplicationAPI(self.command.clone());
         let cmd_str = serde_json::to_string(&command)?;

--- a/local-storage/src/provider.rs
+++ b/local-storage/src/provider.rs
@@ -217,7 +217,6 @@ impl StorageProvider for SqliteStorageProvider {
         offset: u32,
         window_size: u32,
     ) -> Result<Vec<StoredBlock>> {
-        println!("LIMIT {window_size} OFFSET {offset}");
         let blocks: Vec<StoredBlock> = self
             .conn
             .prepare(
@@ -252,17 +251,7 @@ impl StorageProvider for SqliteStorageProvider {
             .filter_map(|b| b.ok())
             .collect();
 
-        println!("provider found {} blocks", blocks.len());
-
         Ok(blocks)
-
-        //  {
-        //     Ok(mut block) => {
-        //         block.links = self.get_links_by_cid(cid)?;
-        //         Ok(block)
-        //     }
-        //     Err(e) => bail!(StorageError::BlockNotFound(cid.to_string(), e.to_string())),
-        // }
     }
 
     fn get_all_dag_cids(&self, cid: &str) -> Result<Vec<String>> {
@@ -284,8 +273,6 @@ impl StorageProvider for SqliteStorageProvider {
             })?
             .filter_map(|b| b.ok())
             .collect();
-
-        println!("provider found {} cids", cids.len());
 
         Ok(cids)
     }
@@ -321,8 +308,6 @@ impl StorageProvider for SqliteStorageProvider {
             .filter_map(|b| b.ok())
             .collect();
 
-        println!("provider found {} blocks", blocks.len());
-
         Ok(blocks)
     }
 
@@ -356,8 +341,6 @@ impl StorageProvider for SqliteStorageProvider {
             })?
             .filter_map(|b| b.ok())
             .collect();
-
-        println!("provider found {} blocks", blocks.len());
 
         Ok(blocks)
     }

--- a/local-storage/src/provider.rs
+++ b/local-storage/src/provider.rs
@@ -14,6 +14,15 @@ pub trait StorageProvider {
     fn get_links_by_cid(&self, cid: &str) -> Result<Vec<String>>;
     fn list_available_dags(&self) -> Result<Vec<String>>;
     fn get_missing_cid_blocks(&self, cid: &str) -> Result<Vec<String>>;
+    fn get_dag_blocks_by_window(
+        &self,
+        cid: &str,
+        offset: u32,
+        window_size: u32,
+    ) -> Result<Vec<StoredBlock>>;
+    fn get_all_dag_cids(&self, cid: &str) -> Result<Vec<String>>;
+    fn get_all_dag_blocks(&self, cid: &str) -> Result<Vec<StoredBlock>>;
+    fn get_all_blocks_under_cid(&self, cid: &str) -> Result<Vec<StoredBlock>>;
 }
 
 pub struct SqliteStorageProvider {
@@ -200,6 +209,157 @@ impl StorageProvider for SqliteStorageProvider {
             })
             .collect();
         Ok(cids)
+    }
+
+    fn get_dag_blocks_by_window(
+        &self,
+        cid: &str,
+        offset: u32,
+        window_size: u32,
+    ) -> Result<Vec<StoredBlock>> {
+        println!("LIMIT {window_size} OFFSET {offset}");
+        let blocks: Vec<StoredBlock> = self
+            .conn
+            .prepare(
+                "
+            WITH RECURSIVE cids(x,y) AS (
+                SELECT cid,data FROM blocks WHERE cid = (?1)
+                UNION
+                SELECT cid,data FROM blocks b 
+                    INNER JOIN links l ON b.cid==l.block_cid 
+                    INNER JOIN cids ON (root_cid=x)
+            )
+            SELECT x,y FROM cids
+            LIMIT (?2) OFFSET (?3);
+            ",
+            )?
+            .query_map(
+                [cid, &format!("{window_size}"), &format!("{offset}")],
+                |row| {
+                    let cid_str: String = row.get(0)?;
+                    let data: Vec<u8> = row.get(1)?;
+                    let links = match self.get_links_by_cid(&cid_str) {
+                        Ok(links) => links,
+                        Err(_) => vec![],
+                    };
+                    Ok(StoredBlock {
+                        cid: cid_str,
+                        data,
+                        links,
+                    })
+                },
+            )?
+            .filter_map(|b| b.ok())
+            .collect();
+
+        println!("provider found {} blocks", blocks.len());
+
+        Ok(blocks)
+
+        //  {
+        //     Ok(mut block) => {
+        //         block.links = self.get_links_by_cid(cid)?;
+        //         Ok(block)
+        //     }
+        //     Err(e) => bail!(StorageError::BlockNotFound(cid.to_string(), e.to_string())),
+        // }
+    }
+
+    fn get_all_dag_cids(&self, cid: &str) -> Result<Vec<String>> {
+        let cids: Vec<String> = self
+            .conn
+            .prepare(
+                "
+                WITH RECURSIVE cids(x) AS (
+                    VALUES(?1)
+                    UNION
+                    SELECT block_cid FROM links JOIN cids ON root_cid=x
+                )
+                SELECT x FROM cids;
+            ",
+            )?
+            .query_map([cid], |row| {
+                let cid_str: String = row.get(0)?;
+                Ok(cid_str)
+            })?
+            .filter_map(|b| b.ok())
+            .collect();
+
+        println!("provider found {} cids", cids.len());
+
+        Ok(cids)
+    }
+
+    fn get_all_dag_blocks(&self, cid: &str) -> Result<Vec<StoredBlock>> {
+        let blocks: Vec<StoredBlock> = self
+            .conn
+            .prepare(
+                "
+            WITH RECURSIVE cids(x,y) AS (
+                SELECT cid,data FROM blocks WHERE cid = (?1)
+                UNION
+                SELECT cid,data FROM blocks b 
+                    INNER JOIN links l ON b.cid==l.block_cid 
+                    INNER JOIN cids ON (root_cid=x)
+            )
+            SELECT x,y FROM cids
+            ",
+            )?
+            .query_map([cid], |row| {
+                let cid_str: String = row.get(0)?;
+                let data: Vec<u8> = row.get(1)?;
+                let links = match self.get_links_by_cid(&cid_str) {
+                    Ok(links) => links,
+                    Err(_) => vec![],
+                };
+                Ok(StoredBlock {
+                    cid: cid_str,
+                    data,
+                    links,
+                })
+            })?
+            .filter_map(|b| b.ok())
+            .collect();
+
+        println!("provider found {} blocks", blocks.len());
+
+        Ok(blocks)
+    }
+
+    fn get_all_blocks_under_cid(&self, cid: &str) -> Result<Vec<StoredBlock>> {
+        let blocks: Vec<StoredBlock> = self
+            .conn
+            .prepare(
+                "
+            WITH RECURSIVE cids(x,y) AS (
+                SELECT cid,data FROM blocks WHERE cid = (?1)
+                UNION
+                SELECT cid,data FROM blocks b 
+                    INNER JOIN links l ON b.cid==l.block_cid 
+                    INNER JOIN cids ON (root_cid=x)
+            )
+            SELECT x,y FROM cids
+            ",
+            )?
+            .query_map([cid], |row| {
+                let cid_str: String = row.get(0)?;
+                let data: Vec<u8> = row.get(1)?;
+                let links = match self.get_links_by_cid(&cid_str) {
+                    Ok(links) => links,
+                    Err(_) => vec![],
+                };
+                Ok(StoredBlock {
+                    cid: cid_str,
+                    data,
+                    links,
+                })
+            })?
+            .filter_map(|b| b.ok())
+            .collect();
+
+        println!("provider found {} blocks", blocks.len());
+
+        Ok(blocks)
     }
 }
 

--- a/local-storage/src/storage.rs
+++ b/local-storage/src/storage.rs
@@ -89,7 +89,7 @@ impl Storage {
             bail!(StorageError::DagIncomplete(cid.to_string()))
         }
         // Fetch all blocks tied to links under given cid
-        let child_blocks = self.get_all_dag_blocks(&cid)?;
+        let child_blocks = self.get_all_dag_blocks(cid)?;
         // Open up file path for writing
         let mut output_file = FsFile::create(path)?;
         // Walk the StoredBlocks and write out to path
@@ -114,21 +114,6 @@ impl Storage {
         self.provider.get_block_by_cid(cid)
     }
 
-    // pub fn get_all_blocks_under_cid(&self, cid: &str) -> Result<Vec<StoredBlock>> {
-    //     // Get StoredBlock by cid and check for links
-    //     let root_block = self.provider.get_block_by_cid(cid)?;
-    //     // If links, grab all appropriate StoredBlocks
-    //     let mut child_blocks = vec![];
-    //     for link in root_block.links {
-    //         let block = self.provider.get_block_by_cid(&link)?;
-    //         if !block.links.is_empty() {
-    //             child_blocks.append(&mut self.get_all_blocks_under_cid(&block.cid)?);
-    //         }
-    //         child_blocks.push(block);
-    //     }
-    //     Ok(child_blocks)
-    // }
-
     pub fn get_all_dag_cids(&self, cid: &str) -> Result<Vec<String>> {
         self.provider.get_all_dag_cids(cid)
     }
@@ -136,22 +121,6 @@ impl Storage {
     pub fn get_all_dag_blocks(&self, cid: &str) -> Result<Vec<StoredBlock>> {
         self.provider.get_all_dag_blocks(cid)
     }
-
-    // pub fn get_dag_blocks(&self, cid: &str) -> Result<Vec<StoredBlock>> {
-    //     // Get StoredBlock by cid and check for links
-    //     let root_block = self.provider.get_block_by_cid(cid)?;
-    //     // If links, grab all appropriate StoredBlocks
-    //     let mut blocks = vec![];
-    //     for link in &root_block.links {
-    //         let block = self.provider.get_block_by_cid(&link)?;
-    //         if !block.links.is_empty() {
-    //             blocks.append(&mut self.get_dag_blocks(&block.cid)?);
-    //         }
-    //         blocks.push(block);
-    //     }
-    //     blocks.push(root_block);
-    //     Ok(blocks)
-    // }
 
     pub fn import_block(&self, block: &StoredBlock) -> Result<()> {
         info!("Importing block {}", block.cid);
@@ -280,7 +249,7 @@ pub mod tests {
         }
     }
 
-    // #[test]
+    #[test]
     pub fn test_get_dag_blocks_by_window() {
         let harness = TestHarness::new();
         let temp_dir = assert_fs::TempDir::new().unwrap();
@@ -300,22 +269,16 @@ pub mod tests {
         let all_dag_blocks = harness.storage.get_all_dag_blocks(&cid).unwrap();
 
         for chunk in all_dag_blocks.chunks(window_size as usize).into_iter() {
-            println!("comparing blocks for {window_num} of {window_size}");
             let window_blocks = harness
                 .storage
                 .get_dag_blocks_by_window(&cid, window_size, window_num)
                 .unwrap();
-            println!(
-                "chunk len {} - window len {}",
-                chunk.len(),
-                window_blocks.len()
-            );
             assert_eq!(chunk, &window_blocks);
             window_num += 1;
         }
     }
 
-    // #[test]
+    #[test]
     pub fn compare_get_blocks_to_get_cids() {
         let harness = TestHarness::new();
         let temp_dir = assert_fs::TempDir::new().unwrap();

--- a/local-storage/src/storage.rs
+++ b/local-storage/src/storage.rs
@@ -18,7 +18,8 @@ pub struct Storage {
 }
 
 // TODO: Make this configurable
-const BLOCK_SIZE: usize = 256;
+// Changing to 1MB to optimize for larger files
+const BLOCK_SIZE: usize = 1024 * 100;
 
 impl Storage {
     pub fn new(provider: Box<dyn StorageProvider>) -> Self {
@@ -39,6 +40,8 @@ impl Storage {
         let blocks = blocks?;
         let mut root_cid: Option<String> = None;
 
+        let mut stored_blocks = vec![];
+
         blocks.iter().for_each(|b| {
             let links = b
                 .links()
@@ -50,13 +53,22 @@ impl Storage {
                 data: b.data().to_vec(),
                 links,
             };
+            // First validate each block
+            if let Err(e) = stored.validate() {
+                error!("Failed to validate {}, {e}", b.cid());
+            }
             if let Err(e) = self.provider.import_block(&stored) {
                 error!("Failed to import block {e}");
             }
             if !stored.links.is_empty() {
-                root_cid = Some(stored.cid);
+                root_cid = Some(stored.cid.clone());
             }
+            stored_blocks.push(stored);
         });
+        info!("Validating imported blocks {}", blocks.len());
+        if let Err(e) = crate::block::validate_dag(&stored_blocks) {
+            error!("Failed to validate dag on import: {e}");
+        }
         if blocks.len() == 1 {
             if let Some(first) = blocks.first() {
                 root_cid = Some(first.cid().to_string());
@@ -77,7 +89,7 @@ impl Storage {
             bail!(StorageError::DagIncomplete(cid.to_string()))
         }
         // Fetch all blocks tied to links under given cid
-        let child_blocks = self.get_all_blocks_under_cid(cid)?;
+        let child_blocks = self.get_all_dag_blocks(&cid)?;
         // Open up file path for writing
         let mut output_file = FsFile::create(path)?;
         // Walk the StoredBlocks and write out to path
@@ -102,32 +114,44 @@ impl Storage {
         self.provider.get_block_by_cid(cid)
     }
 
-    pub fn get_all_blocks_under_cid(&self, cid: &str) -> Result<Vec<StoredBlock>> {
-        // Get StoredBlock by cid and check for links
-        let root_block = self.provider.get_block_by_cid(cid)?;
-        // If links, grab all appropriate StoredBlocks
-        let mut child_blocks = vec![];
-        for link in root_block.links {
-            let block = self.provider.get_block_by_cid(&link)?;
-            if !block.links.is_empty() {
-                child_blocks.append(&mut self.get_all_blocks_under_cid(&block.cid)?);
-            }
-            child_blocks.push(block);
-        }
-        Ok(child_blocks)
+    // pub fn get_all_blocks_under_cid(&self, cid: &str) -> Result<Vec<StoredBlock>> {
+    //     // Get StoredBlock by cid and check for links
+    //     let root_block = self.provider.get_block_by_cid(cid)?;
+    //     // If links, grab all appropriate StoredBlocks
+    //     let mut child_blocks = vec![];
+    //     for link in root_block.links {
+    //         let block = self.provider.get_block_by_cid(&link)?;
+    //         if !block.links.is_empty() {
+    //             child_blocks.append(&mut self.get_all_blocks_under_cid(&block.cid)?);
+    //         }
+    //         child_blocks.push(block);
+    //     }
+    //     Ok(child_blocks)
+    // }
+
+    pub fn get_all_dag_cids(&self, cid: &str) -> Result<Vec<String>> {
+        self.provider.get_all_dag_cids(cid)
     }
 
-    pub fn get_dag_blocks(&self, cid: &str) -> Result<Vec<StoredBlock>> {
-        // Get StoredBlock by cid and check for links
-        let root_block = self.provider.get_block_by_cid(cid)?;
-        // If links, grab all appropriate StoredBlocks
-        let mut blocks = vec![];
-        for link in &root_block.links {
-            blocks.push(self.provider.get_block_by_cid(link)?);
-        }
-        blocks.push(root_block);
-        Ok(blocks)
+    pub fn get_all_dag_blocks(&self, cid: &str) -> Result<Vec<StoredBlock>> {
+        self.provider.get_all_dag_blocks(cid)
     }
+
+    // pub fn get_dag_blocks(&self, cid: &str) -> Result<Vec<StoredBlock>> {
+    //     // Get StoredBlock by cid and check for links
+    //     let root_block = self.provider.get_block_by_cid(cid)?;
+    //     // If links, grab all appropriate StoredBlocks
+    //     let mut blocks = vec![];
+    //     for link in &root_block.links {
+    //         let block = self.provider.get_block_by_cid(&link)?;
+    //         if !block.links.is_empty() {
+    //             blocks.append(&mut self.get_dag_blocks(&block.cid)?);
+    //         }
+    //         blocks.push(block);
+    //     }
+    //     blocks.push(root_block);
+    //     Ok(blocks)
+    // }
 
     pub fn import_block(&self, block: &StoredBlock) -> Result<()> {
         info!("Importing block {}", block.cid);
@@ -140,6 +164,19 @@ impl Storage {
 
     pub fn list_available_dags(&self) -> Result<Vec<String>> {
         self.provider.list_available_dags()
+    }
+
+    pub fn get_dag_blocks_by_window(
+        &self,
+        cid: &str,
+        window_size: u32,
+        window_num: u32,
+    ) -> Result<Vec<StoredBlock>> {
+        println!("offset = {} * {}", window_size, window_num);
+        let offset = window_size * window_num;
+
+        self.provider
+            .get_dag_blocks_by_window(cid, offset, window_size)
     }
 }
 
@@ -198,7 +235,7 @@ pub mod tests {
         test_file
             .write_binary(
                 "654684646847616846846876168468416874616846416846846186468464684684648684684"
-                    .repeat(10)
+                    .repeat(500)
                     .as_bytes(),
             )
             .unwrap();
@@ -217,7 +254,7 @@ pub mod tests {
 
     #[test]
     pub fn export_from_storage_various_file_sizes_binary_data() {
-        for size in [100, 200, 300, 500, 1000] {
+        for size in [100, 200, 300, 500, 1_000] {
             let harness = TestHarness::new();
             let temp_dir = assert_fs::TempDir::new().unwrap();
             let test_file = temp_dir.child("data.txt");
@@ -241,6 +278,61 @@ pub mod tests {
             assert_eq!(test_file_contents.len(), next_test_file_contents.len());
             assert_eq!(test_file_contents, next_test_file_contents);
         }
+    }
+
+    // #[test]
+    pub fn test_get_dag_blocks_by_window() {
+        let harness = TestHarness::new();
+        let temp_dir = assert_fs::TempDir::new().unwrap();
+        let test_file = temp_dir.child("data.txt");
+
+        let data_size = BLOCK_SIZE * 50;
+        let mut data = Vec::<u8>::new();
+        data.resize(data_size, 1);
+        thread_rng().fill_bytes(&mut data);
+
+        test_file.write_binary(&data).unwrap();
+        let cid = harness.storage.import_path(test_file.path()).unwrap();
+
+        let window_size: u32 = 10;
+        let mut window_num = 0;
+
+        let all_dag_blocks = harness.storage.get_all_dag_blocks(&cid).unwrap();
+
+        for chunk in all_dag_blocks.chunks(window_size as usize).into_iter() {
+            println!("comparing blocks for {window_num} of {window_size}");
+            let window_blocks = harness
+                .storage
+                .get_dag_blocks_by_window(&cid, window_size, window_num)
+                .unwrap();
+            println!(
+                "chunk len {} - window len {}",
+                chunk.len(),
+                window_blocks.len()
+            );
+            assert_eq!(chunk, &window_blocks);
+            window_num += 1;
+        }
+    }
+
+    // #[test]
+    pub fn compare_get_blocks_to_get_cids() {
+        let harness = TestHarness::new();
+        let temp_dir = assert_fs::TempDir::new().unwrap();
+        let test_file = temp_dir.child("data.txt");
+
+        let data_size = BLOCK_SIZE * 50;
+        let mut data = Vec::<u8>::new();
+        data.resize(data_size, 1);
+        thread_rng().fill_bytes(&mut data);
+
+        test_file.write_binary(&data).unwrap();
+        let cid = harness.storage.import_path(test_file.path()).unwrap();
+
+        let blocks = harness.storage.get_all_dag_blocks(&cid).unwrap();
+        let cids = harness.storage.get_all_dag_cids(&cid).unwrap();
+
+        assert_eq!(blocks.len(), cids.len());
     }
 
     // TODO: duplicated data is not being handled correctly right now, need to fix this

--- a/messages/src/api.rs
+++ b/messages/src/api.rs
@@ -62,11 +62,11 @@ pub enum ApplicationAPI {
     },
     /// Information about the next pass used for calculating
     /// data transfer parameters
-    NextPassInfo {
-        duration: u32,
-        send_bytes: u32,
-        receive_bytes: u32,
-    },
+    // NextPassInfo {
+    //     duration: u32,
+    //     send_bytes: u32,
+    //     receive_bytes: u32,
+    // },
     /// Request Available Blocks
     RequestAvailableBlocks,
     /// Advertise all available blocks by CID
@@ -78,7 +78,7 @@ pub enum ApplicationAPI {
         cid: String,
     },
     /// Request available DAGs
-    RequestAvailableDags,
+    // RequestAvailableDags,
     /// Advertise available DAGs as a map of CID to filename
     // AvailableDags { dags: BTreeMap<String, String> },
     /// Delete block from local store

--- a/messages/src/api.rs
+++ b/messages/src/api.rs
@@ -60,13 +60,6 @@ pub enum ApplicationAPI {
     Receive {
         listen_addr: String,
     },
-    /// Information about the next pass used for calculating
-    /// data transfer parameters
-    // NextPassInfo {
-    //     duration: u32,
-    //     send_bytes: u32,
-    //     receive_bytes: u32,
-    // },
     /// Request Available Blocks
     RequestAvailableBlocks,
     /// Advertise all available blocks by CID
@@ -77,10 +70,6 @@ pub enum ApplicationAPI {
     DeleteCid {
         cid: String,
     },
-    /// Request available DAGs
-    // RequestAvailableDags,
-    /// Advertise available DAGs as a map of CID to filename
-    // AvailableDags { dags: BTreeMap<String, String> },
     /// Delete block from local store
     DeleteBlock {
         cid: String,
@@ -99,4 +88,16 @@ pub enum ApplicationAPI {
     Version {
         version: String,
     },
+    // TODO: Implement later
+    // Information about the next pass used for calculating
+    // data transfer parameters
+    // NextPassInfo {
+    //     duration: u32,
+    //     send_bytes: u32,
+    //     receive_bytes: u32,
+    // },
+    // Request available DAGs
+    // RequestAvailableDags,
+    // Advertise available DAGs as a map of CID to filename
+    // AvailableDags { dags: BTreeMap<String, String> },
 }

--- a/messages/src/protocol.rs
+++ b/messages/src/protocol.rs
@@ -65,8 +65,8 @@ pub enum DataProtocol {
         cid: String,
         blocks: Vec<String>,
     },
-    /// Sets current connected state
-    SetConnected {
-        connected: bool,
-    },
+    // Sets current connected state
+    // SetConnected {
+    //     connected: bool,
+    // },
 }

--- a/messages/src/protocol.rs
+++ b/messages/src/protocol.rs
@@ -65,8 +65,4 @@ pub enum DataProtocol {
         cid: String,
         blocks: Vec<String>,
     },
-    // Sets current connected state
-    // SetConnected {
-    //     connected: bool,
-    // },
 }

--- a/myceli/src/config.rs
+++ b/myceli/src/config.rs
@@ -11,7 +11,7 @@ pub struct Config {
     pub retry_timeout_duration: u64,
     pub storage_path: String,
     pub mtu: u16,
-    pub window_size: u8,
+    pub window_size: u32,
 }
 
 impl Default for Config {

--- a/myceli/src/handlers.rs
+++ b/myceli/src/handlers.rs
@@ -13,7 +13,7 @@ pub fn import_file(path: &str, storage: Rc<Storage>) -> Result<Message> {
 }
 
 pub fn validate_dag(cid: &str, storage: Rc<Storage>) -> Result<Message> {
-    let dag_blocks = storage.get_dag_blocks(cid)?;
+    let dag_blocks = storage.get_all_dag_blocks(cid)?;
     let resp = match local_storage::block::validate_dag(&dag_blocks) {
         Ok(_) => "Dag is valid".to_string(),
         Err(e) => e.to_string(),
@@ -167,7 +167,7 @@ pub mod tests {
 
         let blocks = harness
             .storage
-            .get_all_blocks_under_cid(&imported_file_cid)
+            .get_all_dag_blocks(&imported_file_cid)
             .unwrap();
         for block in blocks {
             let (validated_cid, result) = match validate_dag(&block.cid, harness.storage.clone()) {

--- a/myceli/tests/utils/mod.rs
+++ b/myceli/tests/utils/mod.rs
@@ -49,7 +49,7 @@ impl TestListener {
 
     pub fn generate_file(&self) -> Result<String> {
         let mut data = Vec::<u8>::new();
-        data.resize(256 * 5, 1);
+        data.resize(256 * 50, 1);
         thread_rng().fill_bytes(&mut data);
 
         let tmp_file = self.test_dir.child("test.file");

--- a/testing/testing-plan.md
+++ b/testing/testing-plan.md
@@ -20,15 +20,15 @@ Command Details:
 
 This test case passes if both steps pass.
 
-## Test Case - Retrieve an IPFS File
+## Test Case - Transmit an IPFS File (Ground to Space)
 
 Steps:
-1. Using the controller software, send the `ImportFile` command to the `myceli` space instance with a known good path for the one-pass payload file.
+1. Using the controller software, send the `ImportFile` command to the `myceli` ground instance with a known good path for the one-pass payload file.
     - This step passes if an `FileImported` response with CID is received. Any other response / no response is a failure.
-1. Using the controller software, send the `TransmitDag` command to the `myceli` space instance with the CID obtained from the `FileImported` response and with the network address of the space-to-ground radio link.
-1. Using the controller software, send the `ValidateDag` command to the `myceli` ground instance with the CID obtained from the `FileImported` response.
+1. Using the controller software, send the `TransmitDag` command to the `myceli` ground instance with the CID obtained from the `FileImported` response and with the network address of the ground-to-space radio link.
+1. Using the controller software, send the `ValidateDag` command to the `myceli` space instance with the CID obtained from the `FileImported` response.
     - This step passes if an `ValidateDagResponse` response with true. Any other response / no response is a failure.
-1. Using the controller software, send the `ExportDag` command to the `myceli` ground instance with the CID obtained from the `FileImported` response and a writeable file path.
+1. Using the controller software, send the `ExportDag` command to the `myceli` space instance with the CID obtained from the `FileImported` response and a writeable file path.
     - This step passes if `myceli` is able to correctly write a file to the given file path.
 
 Command Details:
@@ -43,7 +43,7 @@ Command Details:
 
 This test case passes if the final step is successful and the resulting written file matches the onboard payload file.
 
-## Test Case - Send and Retrieve New IPFS File
+## Test Case - Transmit Back & Forth, and Export File with IPFS
 
 Steps:
 1. Using the controller software, send the `ImportFile` command to the `myceli` ground instance with a known good path for the one-pass payload file.


### PR DESCRIPTION
A variety of fixes to issues found while doing performance testing:
- Increase default MTU to 512 bytes to accommodate more realistic systems
- Move window fetching logic into storage layer for better performance with larger files
- Move functions for fetching all DAG cids & blocks into storage layer
- Increase default file block size to 100kb for better performance when importing larger files
- Fixed issue where setting connection to false would "complete" a dag transfer
- Small revision to testing plan