### PR TITLE
Various fixes from testing v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
 # Changelog
 
+## [0.6.5] - Unreleased
 
-## [0.6.4] - Unreleased
+### Added
+
+- Added `DagExported` and `DagExportFailed` responses to `ExportDag` command.
+- Added `DagTransmissionComplete` response when a DAG has been completely transmitted.
+
+### Changed
+
+- MTU is now an optional flag on `controller`
+- Added `block_size` as a `myceli` config option for controlling IPFS block size in file chunking
+- Changed default `block_size` to 3072 bytes
+- Fixed cases where responses inside of dag transfer session weren't sent to original target address
+
+## [0.6.4] - 2023-05-15
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "controller"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "hyphae"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "ipfs-unixfs"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -1194,7 +1194,7 @@ checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "local-storage"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "messages"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "cid",
  "clap",
@@ -1390,7 +1390,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "myceli"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "transports"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "cid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,6 +1206,7 @@ dependencies = [
  "rusqlite",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.3"
+version = "0.6.5"
 edition = "2021"
 license = "Apache-2.0/MIT"
 rust-version = "1.68.1"

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -8,6 +8,8 @@ use transports::{Transport, UdpTransport};
 #[clap(about = "Control a Myceli instance")]
 pub struct Cli {
     instance_addr: String,
+    #[arg(short, long, default_value = "512")]
+    mtu: u16,
     #[arg(short, long)]
     listen_mode: bool,
     #[arg(short, long, default_value = "0.0.0.0:8090")]
@@ -18,7 +20,7 @@ pub struct Cli {
 
 impl Cli {
     pub async fn run(&self) -> Result<()> {
-        let transport = UdpTransport::new(&self.bind_address, 512)?;
+        let transport = UdpTransport::new(&self.bind_address, self.mtu)?;
 
         let command = Message::ApplicationAPI(self.command.clone());
         let cmd_str = serde_json::to_string(&command)?;

--- a/ipfs-unixfs/Cargo.toml
+++ b/ipfs-unixfs/Cargo.toml
@@ -20,6 +20,7 @@ multihash.workspace = true
 num_enum.workspace = true
 prost.workspace = true
 tokio = { workspace = true, features = ["fs"] }
+tokio-util = { workspace = true, features = ["io-util"] }
 
 [dev-dependencies]
 # criterion = { workspace = true, features = ["async_tokio"] }

--- a/local-storage/Cargo.toml
+++ b/local-storage/Cargo.toml
@@ -15,6 +15,7 @@ ipfs-unixfs.workspace = true
 rusqlite.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+tokio-util = { workspace = true, features = ["io-util"] }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/local-storage/src/storage.rs
+++ b/local-storage/src/storage.rs
@@ -259,17 +259,14 @@ pub mod tests {
         let cid = harness.storage.import_path(test_file.path()).unwrap();
 
         let window_size: u32 = 10;
-        let mut window_num = 0;
-
         let all_dag_blocks = harness.storage.get_all_dag_blocks(&cid).unwrap();
 
-        for chunk in all_dag_blocks.chunks(window_size as usize).into_iter() {
+        for (window_num, chunk) in all_dag_blocks.chunks(window_size as usize).enumerate() {
             let window_blocks = harness
                 .storage
-                .get_dag_blocks_by_window(&cid, window_size, window_num)
+                .get_dag_blocks_by_window(&cid, window_size, window_num.try_into().unwrap())
                 .unwrap();
             assert_eq!(chunk, &window_blocks);
-            window_num += 1;
         }
     }
 

--- a/local-storage/src/storage.rs
+++ b/local-storage/src/storage.rs
@@ -62,7 +62,7 @@ impl Storage {
                 root_cid = Some(stored.cid);
             }
         });
-        info!("Validating imported blocks {}", blocks.len());
+        println!("Validating imported blocks {}", blocks.len());
         if blocks.len() == 1 {
             if let Some(first) = blocks.first() {
                 root_cid = Some(first.cid().to_string());
@@ -135,7 +135,6 @@ impl Storage {
         window_size: u32,
         window_num: u32,
     ) -> Result<Vec<StoredBlock>> {
-        println!("offset = {} * {}", window_size, window_num);
         let offset = window_size * window_num;
 
         self.provider

--- a/local-storage/src/util.rs
+++ b/local-storage/src/util.rs
@@ -25,6 +25,7 @@ pub(crate) fn verify_dag(blocks: &[StoredBlock]) -> Result<()> {
             // If the linked CID exists in our collection of blocks, set that CID's degree
             if let Some(degree) = indegree.get_mut(&link_cid) {
                 *degree = 1;
+                // println!("Setting degree of {link_cid} to {}", *degree);
             } else {
                 bail!("Links do not match blocks");
             }
@@ -51,7 +52,7 @@ pub(crate) fn verify_dag(blocks: &[StoredBlock]) -> Result<()> {
     while !queue.is_empty() {
         // this is a safe unwrap as the queue is not empty
         let node: &StoredBlock = queue.pop_front().unwrap();
-        // ignore a visite node
+        // ignore a visited node
         if visited.contains(&node.cid.as_str()) {
             continue;
         }
@@ -68,6 +69,7 @@ pub(crate) fn verify_dag(blocks: &[StoredBlock]) -> Result<()> {
             let cid = link.as_str();
             // Grab the degree of the linked cid
             if let Some(degree) = indegree.get_mut(&cid) {
+                // println!("walking to {cid} with {degree}");
                 // mark the degree as seen
                 *degree -= 1;
                 // push a block with in-degree 0 to the queue

--- a/messages/src/api.rs
+++ b/messages/src/api.rs
@@ -55,6 +55,10 @@ pub enum ApplicationAPI {
         target_addr: String,
         retries: u8,
     },
+    /// Indicates that a Dag has been transmitted completely successfully
+    DagTransmissionComplete {
+        cid: String,
+    },
     /// Initiates transmission of block corresponding to the given CID
     TransmitBlock {
         cid: String,

--- a/messages/src/api.rs
+++ b/messages/src/api.rs
@@ -18,6 +18,17 @@ pub enum ApplicationAPI {
         cid: String,
         path: String,
     },
+    /// Used to indicate the failure of a dag export
+    DagExportFailed {
+        cid: String,
+        path: String,
+        error: String,
+    },
+    /// Used to indicate a successful dag export
+    DagExported {
+        cid: String,
+        path: String,
+    },
     /// Sets current connected state
     SetConnected {
         #[arg(action(clap::ArgAction::Set), required(true))]

--- a/messages/src/protocol.rs
+++ b/messages/src/protocol.rs
@@ -37,7 +37,6 @@ pub enum DataProtocol {
     // in order to continue transmitting the dag
     RetryDagSession {
         cid: String,
-        target_addr: String,
     },
     // Requests windowed transmission of a dag
     RequestTransmitDag {

--- a/myceli/src/config.rs
+++ b/myceli/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub storage_path: String,
     pub mtu: u16,
     pub window_size: u32,
+    pub block_size: u32,
 }
 
 impl Default for Config {
@@ -24,8 +25,11 @@ impl Default for Config {
             // Default storage dir
             storage_path: "storage".to_string(),
             // Default MTU appropriate for dev radio
-            mtu: 60,
+            mtu: 512,
+            // Default to sending five blocks at a time
             window_size: 5,
+            // Default to 3 kilobyte blocks
+            block_size: 1024 * 3,
         }
     }
 }

--- a/myceli/src/handlers.rs
+++ b/myceli/src/handlers.rs
@@ -74,6 +74,8 @@ pub mod tests {
     use local_storage::provider::SqliteStorageProvider;
     use rand::{thread_rng, RngCore};
 
+    const BLOCK_SIZE: u32 = 1024 * 3;
+
     struct TestHarness {
         storage: Rc<Storage>,
         db_dir: TempDir,
@@ -85,7 +87,7 @@ pub mod tests {
             let db_path = db_dir.child("storage.db");
             let provider = SqliteStorageProvider::new(db_path.path().to_str().unwrap()).unwrap();
             provider.setup().unwrap();
-            let storage = Rc::new(Storage::new(Box::new(provider)));
+            let storage = Rc::new(Storage::new(Box::new(provider), BLOCK_SIZE));
             TestHarness { storage, db_dir }
         }
 

--- a/myceli/src/listener.rs
+++ b/myceli/src/listener.rs
@@ -128,8 +128,17 @@ impl<T: Transport + Send + 'static> Listener<T> {
                 Some(handlers::import_file(&path, self.storage.clone())?)
             }
             Message::ApplicationAPI(ApplicationAPI::ExportDag { cid, path }) => {
-                self.storage.export_cid(&cid, &PathBuf::from(path))?;
-                None
+                match self.storage.export_cid(&cid, &PathBuf::from(path.clone())) {
+                    Ok(()) => Some(Message::ApplicationAPI(ApplicationAPI::DagExported {
+                        cid,
+                        path,
+                    })),
+                    Err(e) => Some(Message::ApplicationAPI(ApplicationAPI::DagExportFailed {
+                        cid,
+                        path,
+                        error: e.to_string(),
+                    })),
+                }
             }
             Message::ApplicationAPI(ApplicationAPI::RequestAvailableBlocks) => {
                 Some(handlers::request_available_blocks(self.storage.clone())?)

--- a/myceli/src/main.rs
+++ b/myceli/src/main.rs
@@ -36,10 +36,15 @@ fn main() -> Result<()> {
     let udp_transport =
         UdpTransport::new(&cfg.listen_address, cfg.mtu).expect("Failed to create udp transport");
 
-    let mut listener = Listener::new(&resolved_listen_addr, &db_path, Arc::new(udp_transport))
-        .expect("Listener creation failed");
+    let mut listener = Listener::new(
+        &resolved_listen_addr,
+        &db_path,
+        Arc::new(udp_transport),
+        cfg.block_size,
+    )
+    .expect("Listener creation failed");
     listener
-        .start(cfg.retry_timeout_duration, cfg.window_size)
+        .start(cfg.retry_timeout_duration, cfg.window_size, cfg.block_size)
         .expect("Error encountered in listener operation");
     Ok(())
 }

--- a/myceli/src/shipper.rs
+++ b/myceli/src/shipper.rs
@@ -248,6 +248,12 @@ impl<T: Transport + Send + 'static> Shipper<T> {
             } else {
                 info!("Dag transfer session for {cid} is complete");
                 self.end_dag_window_session(cid);
+                self.transmit_msg(
+                    Message::ApplicationAPI(messages::ApplicationAPI::DagTransmissionComplete {
+                        cid: cid.to_string(),
+                    }),
+                    target_addr,
+                )?;
             }
         }
         Ok(())

--- a/myceli/src/shipper.rs
+++ b/myceli/src/shipper.rs
@@ -123,7 +123,7 @@ impl<T: Transport + Send + 'static> Shipper<T> {
                 if *self.connected.lock().unwrap() {
                     let missing_blocks_msg =
                         handlers::get_missing_dag_blocks(&cid, Rc::clone(&self.storage))?;
-                    self.transmit_msg(missing_blocks_msg, &sender_addr)?;
+                    self.transmit_msg(missing_blocks_msg, sender_addr)?;
                 }
             }
             DataProtocol::MissingDagBlocks { cid, blocks } => {

--- a/myceli/tests/listener_test.rs
+++ b/myceli/tests/listener_test.rs
@@ -42,7 +42,7 @@ pub fn test_transmit_receive_block() {
         &transmitter.listen_addr,
     );
 
-    sleep(Duration::from_millis(100));
+    utils::wait_receiving_done(&receiver, &mut controller);
 
     let resp = controller.send_and_recv(&receiver.listen_addr, Message::request_available_blocks());
 
@@ -73,7 +73,7 @@ pub fn test_transmit_receive_dag() {
         &transmitter.listen_addr,
     );
 
-    sleep(Duration::from_millis(2_000));
+    utils::wait_receiving_done(&receiver, &mut controller);
 
     let receiver_blocks =
         controller.send_and_recv(&receiver.listen_addr, Message::request_available_blocks());
@@ -110,7 +110,7 @@ pub fn test_transmit_receive_dag_with_retries() {
         &transmitter.listen_addr,
     );
 
-    sleep(Duration::from_millis(500));
+    utils::wait_receiving_done(&receiver, &mut controller);
 
     let receiver_blocks =
         controller.send_and_recv(&receiver.listen_addr, Message::request_available_blocks());
@@ -147,7 +147,7 @@ pub fn test_import_transmit_export_file() {
         &transmitter.listen_addr,
     );
 
-    sleep(Duration::from_millis(600));
+    utils::wait_receiving_done(&receiver, &mut controller);
 
     let export_path = format!("{}/export", &receiver.test_dir.to_str().unwrap());
     controller.send_msg(
@@ -246,7 +246,7 @@ pub fn test_resume_dag_after_reconnect() {
         &transmitter.listen_addr,
     );
 
-    sleep(Duration::from_millis(2_000));
+    utils::wait_receiving_done(&receiver, &mut controller);
 
     let receiver_blocks =
         controller.send_and_recv(&receiver.listen_addr, Message::request_available_blocks());
@@ -261,7 +261,7 @@ pub fn test_resume_dag_after_reconnect() {
         &transmitter.listen_addr,
     );
 
-    sleep(Duration::from_millis(2_000));
+    utils::wait_receiving_done(&receiver, &mut controller);
 
     let receiver_blocks =
         controller.send_and_recv(&receiver.listen_addr, Message::request_available_blocks());
@@ -303,7 +303,7 @@ pub fn test_no_transmit_after_disconnect() {
         &transmitter.listen_addr,
     );
 
-    sleep(Duration::from_millis(2_000));
+    utils::wait_receiving_done(&receiver, &mut controller);
 
     let receiver_blocks =
         controller.send_and_recv(&receiver.listen_addr, Message::request_available_blocks());
@@ -337,7 +337,7 @@ pub fn test_transmit_resume_after_timeout() {
         &transmitter.listen_addr,
     );
 
-    sleep(Duration::from_millis(2_000));
+    sleep(Duration::from_secs(1));
 
     receiver.start().unwrap();
 
@@ -354,7 +354,7 @@ pub fn test_transmit_resume_after_timeout() {
         &transmitter.listen_addr,
     );
 
-    sleep(Duration::from_millis(2_000));
+    utils::wait_receiving_done(&receiver, &mut controller);
 
     let receiver_blocks =
         controller.send_and_recv(&receiver.listen_addr, Message::request_available_blocks());

--- a/myceli/tests/utils/mod.rs
+++ b/myceli/tests/utils/mod.rs
@@ -15,6 +15,33 @@ use transports::{Transport, UdpTransport};
 
 const BLOCK_SIZE: u32 = 1024 * 3;
 
+pub fn wait_receiving_done(receiver: &TestListener, controller: &mut TestController) {
+    let mut prev_num_blocks = 0;
+    let mut num_retries = 0;
+
+    loop {
+        let current_blocks =
+            if let Message::ApplicationAPI(messages::ApplicationAPI::AvailableBlocks { cids }) =
+                controller.send_and_recv(&receiver.listen_addr, Message::request_available_blocks())
+            {
+                cids
+            } else {
+                panic!("Failed to get correct response to blocks request");
+            };
+        let current_num_blocks = current_blocks.len();
+        if current_num_blocks > prev_num_blocks {
+            prev_num_blocks = current_num_blocks;
+            num_retries = 0;
+        } else {
+            if num_retries > 10 {
+                break;
+            }
+            num_retries += 1;
+        }
+        sleep(Duration::from_millis(10));
+    }
+}
+
 pub struct TestListener {
     pub listen_addr: String,
     pub test_dir: TempDir,

--- a/myceli/tests/utils/mod.rs
+++ b/myceli/tests/utils/mod.rs
@@ -13,6 +13,8 @@ use std::sync::Arc;
 use std::thread::{sleep, spawn};
 use transports::{Transport, UdpTransport};
 
+const BLOCK_SIZE: u32 = 1024 * 3;
+
 pub struct TestListener {
     pub listen_addr: String,
     pub test_dir: TempDir,
@@ -67,9 +69,9 @@ fn start_listener_thread(listen_addr: SocketAddr, db_path: ChildPath) {
         .unwrap();
     transport.set_max_read_attempts(Some(1));
     let transport = Arc::new(transport);
-    let mut listener = Listener::new(&listen_addr, db_path, transport).unwrap();
+    let mut listener = Listener::new(&listen_addr, db_path, transport, BLOCK_SIZE).unwrap();
     listener
-        .start(10, 2)
+        .start(10, 2, BLOCK_SIZE)
         .expect("Error encountered in listener");
 }
 


### PR DESCRIPTION
### Added

- Added `DagExported` and `DagExportFailed` responses to `ExportDag` command.
- Added `DagTransmissionComplete` response when a DAG has been completely transmitted.

### Changed

- MTU is now an optional flag on `controller`
- Added `block_size` as a `myceli` config option for controlling IPFS block size in file chunking
- Changed default `block_size` to 3072 bytes
- Fixed cases where responses inside of dag transfer session weren't sent to original target address