### PR TITLE
hyphae improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56fc6cf8dc8c4158eed8649f9b8b0ea1518eb62b544fe9490d66fa0b349eafe9"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +384,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "cid"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +479,12 @@ dependencies = [
  "tracing-subscriber",
  "transports",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core2"
@@ -788,7 +824,7 @@ checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -949,15 +985,43 @@ name = "hyphae"
 version = "0.6.5"
 dependencies = [
  "anyhow",
+ "bytes",
+ "chrono",
+ "cid",
  "clap",
  "figment",
+ "ipfs-unixfs",
  "messages",
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
  "transports",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1329,7 +1393,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -2195,6 +2259,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,6 +2565,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2611,6 +2692,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/hyphae/Cargo.toml
+++ b/hyphae/Cargo.toml
@@ -8,8 +8,11 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+bytes.workspace = true
+cid.workspace = true
 clap.workspace = true
 figment.workspace = true
+ipfs-unixfs.workspace = true
 messages.workspace = true
 reqwest = { workspace = true, features = ["blocking", "json", "multipart"] }
 serde.workspace = true
@@ -17,3 +20,5 @@ serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 transports.workspace = true
+chrono = "0.4.26"
+thiserror.workspace = true

--- a/hyphae/src/config.rs
+++ b/hyphae/src/config.rs
@@ -25,7 +25,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            myceli_address: "0.0.0.0:8000".to_string(),
+            myceli_address: "0.0.0.0:8001".to_string(),
             listen_to_myceli_address: "0.0.0.0:8100".to_string(),
             kubo_address: "0.0.0.0:5001".to_string(),
             sync_interval: 10_000,

--- a/hyphae/src/config.rs
+++ b/hyphae/src/config.rs
@@ -28,7 +28,7 @@ impl Default for Config {
             myceli_address: "0.0.0.0:8001".to_string(),
             listen_to_myceli_address: "0.0.0.0:8100".to_string(),
             kubo_address: "0.0.0.0:5001".to_string(),
-            sync_interval: 10_000,
+            sync_interval: 20_000,
             myceli_mtu: 512,
             chunk_transmit_throttle: None,
         }

--- a/hyphae/src/config.rs
+++ b/hyphae/src/config.rs
@@ -28,7 +28,7 @@ impl Default for Config {
             myceli_address: "0.0.0.0:8001".to_string(),
             listen_to_myceli_address: "0.0.0.0:8100".to_string(),
             kubo_address: "0.0.0.0:5001".to_string(),
-            sync_interval: 20_000,
+            sync_interval: 1_000,
             myceli_mtu: 512,
             chunk_transmit_throttle: None,
         }

--- a/hyphae/src/indexer.rs
+++ b/hyphae/src/indexer.rs
@@ -20,6 +20,8 @@ pub(crate) struct Indexer<'a> {
     dir: Option<ipfs_unixfs::Block>,
     name_target: Option<String>,
     index_count: usize,
+    pending: Vec<ipfs_unixfs::Block>,
+    index_html_url: String,
 }
 
 type When = DateTime<Utc>;
@@ -35,15 +37,17 @@ struct File {
 struct Index {
     files: BTreeMap<String, File>,
     arch: Option<Box<Index>>,
+    old_arch: String,
+    parsed: bool,
 }
 
-const PARSED: &str = "Already parsed the HTML";
 const DATA_LINE_START: &str = "<!-- ";
+const ARCHIVE_LINK: &str = "<p><a href='archive'>archive of old files</a></p>";
 
 impl<'a> Indexer<'a> {
     // pub fn new(kubo: &'a KuboApi, myceli: &'a MyceliApi) -> Self {
     pub fn new(kubo: &'a KuboApi) -> Self {
-        Self { kubo, key: None, html: String::new(), main: Index::default(), resolved: None, name_target: None, dir: None, index_count: 0 }
+        Self { kubo, key: None, html: String::new(), main: Index::default(), resolved: None, name_target: None, dir: None, index_count: 0, pending: Vec::new(), index_html_url: "/".to_string() }
     }
     pub fn step(&mut self, files: &BTreeMap<String, TransmissionBlock>) -> Result<bool> {
         if self.add_files(files) {
@@ -78,11 +82,28 @@ impl<'a> Indexer<'a> {
                 Err(e) => error!("Error resolving IPNS name: {:?}", & e),
             }
             Ok(true)
-        } else if self.html.is_empty() {
+        } else if !self.html.is_empty() {
+            if self.main.parse_html(&self.html, files) {
+                self.index_html_url.push_str("archive/");
+                info!("Next link bit: {}", self.index_html_url);
+            } else {
+                info!("All parsed! {}", self.index_html_url);
+                self.index_html_url.clear();
+            }
+            self.html.clear();
+            Ok(true)
+        } else if !self.index_html_url.is_empty() {
             self.fetch_html()?;
             Ok(true)
-        } else if self.html != PARSED {
-            self.parse_html(files);
+        } else if let Some(to_upload) = self.pending.pop() {
+            let cid_s = to_upload.cid().to_string();
+            self.kubo.put_block(cid_s.as_str(), &TransmissionBlock {
+                data: to_upload.data().to_vec(),
+                cid: vec![],
+                links: vec![],
+                filename: None,
+            }, false)?;
+            info!("Uploaded {} to Kubo for indexing reasons", cid_s);
             Ok(true)
         } else if let Some(d) = &self.dir {
             self.kubo.put_block(d.cid().to_string().as_str(), &TransmissionBlock {
@@ -90,7 +111,7 @@ impl<'a> Indexer<'a> {
                 cid: vec![],
                 links: vec![],
                 filename: None,
-            })?;
+            }, false)?;
             info!("Uploaded the directory node {}", &d.cid());
             self.name_target = Some(d.cid().to_string());
             self.dir = None;
@@ -105,16 +126,11 @@ impl<'a> Indexer<'a> {
         } else if self.index_count == files.len() {
             debug!("Waiting for new files to arrive.");
             Ok(false)
-        } else if let Ok([index, dir]) = self.main.build() {
-            info!("Will upload index.html {} now, directory {} later", index.cid().to_string(), dir.cid().to_string());
-            self.kubo.put_block(index.cid().to_string().as_str(), &TransmissionBlock {
-                data: index.data().to_vec(),
-                cid: vec![],
-                links: vec![],
-                filename: None,
-            })?;
-            self.dir = Some(dir);
+        } else if let Ok(indexed) = self.main.build() {
+            info!("Built an index, have {} blocks to upload to kubo now", indexed.len());
+            self.dir = indexed.iter().last().cloned();
             self.index_count = files.len();
+            self.pending = indexed;
             Ok(true)
         } else {
             warn!("troubles");
@@ -122,7 +138,7 @@ impl<'a> Indexer<'a> {
         }
     }
     fn add_files(&mut self, files: &BTreeMap<String, TransmissionBlock>) -> bool {
-        if self.html != PARSED {
+        if self.main.is_parsed() {
             debug!("We don't yet have an 'old' index to check for files with existing timestamps.");
             return false;
         }
@@ -148,10 +164,11 @@ impl<'a> Indexer<'a> {
         if let (Some(path), Some(key)) = (&self.resolved, &self.key) {
             if path.is_empty() {
                 info!("We have no HTML to parse.");
-                self.html = PARSED.to_string();
+                self.main.parse_html("", &BTreeMap::default());
             } else {
-                let bytes = self.kubo.get(format!("/ipns/{}/index.html", key.id).as_str())?;
-                info!("Fetched {} bytes of index.html", bytes.len());
+                let url = format!("/ipns/{}{}index.html", key.id, self.index_html_url);
+                let bytes = self.kubo.get(url.as_str())?;
+                info!("Fetched {} bytes of {url}", bytes.len());
                 self.html = String::from_utf8(bytes)?;
             }
             Ok(())
@@ -159,8 +176,147 @@ impl<'a> Indexer<'a> {
             unreachable!()
         }
     }
-    fn parse_html(&mut self, files: &BTreeMap<String, TransmissionBlock>) {
-        for line in self.html.split('\n') {
+}
+
+impl Index {
+    fn is_archived(&self, cid: &String) -> bool {
+        if let Some(a) = &self.arch {
+            a.files.contains_key(cid) || (*a).is_archived(cid)
+        } else {
+            false
+        }
+    }
+    fn build(&mut self) -> Result<Vec<ipfs_unixfs::Block>> {
+        let mut html = "<html><title>Space Files</title><body><table border=1><tr><th>Name</th><th>Import Time</th></tr>\n".to_string();
+        let mut links = Vec::new();
+        let mut files: Vec<File> = self.files.values().map(|f| (*f).clone()).collect();
+        files.sort();
+        const MAX_FILES_PER_INDEX_HTML: usize = 160;
+        if files.len() > MAX_FILES_PER_INDEX_HTML {
+            for f in &files[MAX_FILES_PER_INDEX_HTML..] {
+                self.get_or_create_archive().files.insert(f.cid.clone(), f.clone());
+            }
+            files.truncate(MAX_FILES_PER_INDEX_HTML);
+        }
+        let mut taken: HashSet<String> = HashSet::new();
+        taken.insert("archive".to_string());
+        taken.insert("index.html".to_string());
+        let mut i = 0;
+        for f in files {
+            if html.len() > 1_000_000 {
+                warn!("index.html limited to fit in a single UnixFS node.");
+                break;
+            }
+            let mut real = f.name.clone();
+            while !taken.insert(real.clone()) {
+                real = i.to_string() + real.as_str();
+                i += 1;
+            }
+            let cid = Cid::try_from(f.cid.as_str());
+            if cid.is_err() {
+                continue;
+            }
+            let cid = cid?;
+            info!("Link: {}={}={}", &f.name, &real, &f.cid);
+            links.push(dag_pb::PbLink {
+                hash: Some(cid.to_bytes()),
+                name: Some(real.clone()),
+                tsize: None,//No idea how big it actually is?
+            });
+            let when_str = f.when.to_rfc3339();
+            html.push_str(DATA_LINE_START);
+            html.push_str(&when_str);
+            html.push(' ');
+            html.push_str(&cid.to_string());
+            html.push(' ');
+            html.push_str(&f.name);
+            html.push_str(" -->\n");
+
+            html.push_str("<tr><td><a href='");
+            html.push_str(&real);
+            html.push_str("'>");
+            html.push_str(&f.name);
+            html.push_str("</a></td><td>");
+            html.push_str(&when_str);
+            html.push_str("</td></tr>\n");
+        }
+        html.push_str("</table>\n");
+        let mut result = if let Some(archive) = &mut self.arch {
+            if !self.old_arch.is_empty() {
+                archive.set_old_arch(&self.old_arch);
+                self.old_arch.clear();
+            }
+            let recursed = archive.build()?;
+            if let Some(sub_dag_root) = recursed.iter().last() {
+                links.push(dag_pb::PbLink {
+                    hash: Some(sub_dag_root.cid().to_bytes()),
+                    name: Some("archive".to_string()),
+                    tsize: Some(sub_dag_root.data().len().try_into().unwrap()),
+                });
+            }
+            recursed
+        } else {
+            Vec::new()
+        };
+        if !self.old_arch.is_empty() {
+            links.push(dag_pb::PbLink {
+                hash: Some(Cid::try_from(self.old_arch.as_str())?.to_bytes()),
+                name: Some("archive".to_string()),
+                tsize: None,
+            });
+        }
+        if links.iter().last().map(|l| l.name.clone()) == Some(Some("archive".to_owned())) {
+            html.push_str(ARCHIVE_LINK);
+        }
+        html.push_str("</body></html>");
+        let html_bytes = Bytes::from(html);
+        let byte_count = html_bytes.len() as u64;
+        let node = UnixfsNode::Raw(html_bytes);
+        let index_block = node.encode()?;
+        result.push(index_block.clone());
+        links.push(dag_pb::PbLink {
+            hash: Some(index_block.cid().to_bytes()),
+            name: Some("index.html".to_string()),
+            tsize: Some(byte_count),
+        });
+        let inner = unixfs_pb::Data {
+            r#type: unixfs::DataType::Directory as i32,
+            ..Default::default()
+        };
+        let outer = ipfs_unixfs::builder::encode_unixfs_pb(&inner, links)?;
+        let dir_node = UnixfsNode::Directory(unixfs::Node { outer, inner });
+        result.push(dir_node.encode()?);
+        Ok(result)
+    }
+    fn set_old_arch(&mut self, cid: &str) {
+        if let Some(a) = &mut self.arch {
+            a.set_old_arch(cid);
+        } else {
+            self.old_arch = cid.to_owned();
+        }
+    }
+    fn is_parsed(&self) -> bool {
+        if self.parsed {
+            true
+        } else if let Some(a) = &self.arch {
+            a.is_parsed()
+        } else {
+            false
+        }
+    }
+    fn get_or_create_archive(&mut self) -> &mut Index {
+        if self.arch.is_none() {
+            self.arch = Some(Box::default());
+        }
+        self.arch.as_mut().unwrap()
+    }
+    fn parse_html(&mut self, html: &str, files: &BTreeMap<String, TransmissionBlock>) -> bool {
+        if self.parsed {
+            info!("parse_html() descending to archive index");
+            return self.get_or_create_archive().parse_html(html, files);
+        }
+        let mut result = false;
+        for line in html.split('\n') {
             if line.starts_with(DATA_LINE_START) {
                 let mut toks = line.split_whitespace();
                 toks.next();//discard open comment
@@ -185,92 +341,20 @@ impl<'a> Indexer<'a> {
                 }
                 if files.contains_key(&f.cid) {
                     info!("Re-found old file={:?}", &f);
-                    self.main.files.insert(f.cid.clone(), f);
+                    self.files.insert(f.cid.clone(), f);
                 } else {
                     info!("Missing old file={:?}", &f);
-                    if self.main.arch.is_none() {
-                        self.main.arch = Some(Box::default());
-                    }
-                    self.main.arch.as_mut().unwrap().files.insert(f.cid.clone(), f);
+                    self.get_or_create_archive().files.insert(f.cid.clone(), f);
                 }
+            } else if line.contains(ARCHIVE_LINK) {
+                info!("Found an archive link. Will descend.");
+                result = true;
+            } else if !line.contains("<tr><td><a href") {
+                info!("Ignoring line {}", &line);
             }
         }
-        self.html = PARSED.to_string();
-    }
-}
-
-impl Index {
-    fn is_archived(&self, cid: &String) -> bool {
-        if let Some(a) = &self.arch {
-            a.files.contains_key(cid) || (*a).is_archived(cid)
-        } else {
-            false
-        }
-    }
-    fn build(&self) -> Result<[ipfs_unixfs::Block; 2]> {
-        let mut html = "<html><title>Space Files</title><body><table border=1><tr><th>Name</th><th>Import Time</th></tr>\n".to_string();
-        let mut links = Vec::new();
-        let mut files: Vec<File> = self.files.values().map(|f| (*f).clone()).collect();
-        files.sort();
-        let mut taken: HashSet<String> = HashSet::new();
-        taken.insert("archive".to_string());
-        taken.insert("index.html".to_string());
-        let mut i = 0;
-        for f in files {
-            if html.len() > 1_000_000 {
-                warn!("index.html limited to fit in a single UnixFS node.");
-                break;
-            }
-            let mut real = f.name.clone();
-            while !taken.insert(real.clone()) {
-                real = i.to_string() + real.as_str();
-                i += 1;
-            }
-            let cid = Cid::try_from(f.cid.as_str());
-            if cid.is_err() {
-                continue;
-            }
-            let cid = cid?;
-            info!("Link: {}={}={}", &f.name, &real, &f.cid);
-            links.push(dag_pb::PbLink {
-                hash: Some(cid.to_bytes()),
-                name: Some(real.clone()),
-                tsize: None,
-            });
-            let when_str = f.when.to_rfc3339();
-            html.push_str(DATA_LINE_START);
-            html.push_str(&when_str);
-            html.push(' ');
-            html.push_str(&cid.to_string());
-            html.push(' ');
-            html.push_str(&f.name);
-            html.push_str(" -->\n");
-
-            html.push_str("<tr><td><a href='");
-            html.push_str(&real);
-            html.push_str("'>");
-            html.push_str(&f.name);
-            html.push_str("</a></td><td>");
-            html.push_str(&when_str);
-            html.push_str("</td></tr>\n");
-        }
-        html.push_str("</table></body></html>");
-        let html_bytes = Bytes::from(html);
-        let byte_count = html_bytes.len() as u64;
-        let node = UnixfsNode::Raw(html_bytes);
-        let index_block = node.encode()?;
-        links.push(dag_pb::PbLink {
-            hash: Some(index_block.cid().to_bytes()),
-            name: Some("index.html".to_string()),
-            tsize: Some(byte_count),
-        });
-        let inner = unixfs_pb::Data {
-            r#type: unixfs::DataType::Directory as i32,
-            ..Default::default()
-        };
-        let outer = ipfs_unixfs::builder::encode_unixfs_pb(&inner, links)?;
-        let node = UnixfsNode::Directory(unixfs::Node { outer, inner });
-        Ok([index_block, node.encode()?])
+        self.parsed = true;
+        result
     }
 }
 
@@ -288,14 +372,5 @@ impl Ord for File {
 impl PartialOrd<File> for File {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
-        /*
-    for o in &[self.when.cmp(&other.when).reverse(), self.name.cmp(&other.name)] {
-        if !o.is_eq() {
-            return Some(*o);
-        }
-    }
-    Some(self.cid.cmp(&other.cid))
-
-         */
     }
 }

--- a/hyphae/src/indexer.rs
+++ b/hyphae/src/indexer.rs
@@ -1,43 +1,294 @@
-use super::kubo_api::{Key, KuboApi};
 use anyhow::Result;
-use tracing::{debug, info, warn};
+use bytes::Bytes;
+use chrono::{DateTime, offset::Utc};
+use cid::Cid;
+use messages::TransmissionBlock;
+use std::{cmp::Ordering, collections::{BTreeMap, HashSet}};
+use super::kubo_api::{Key, KuboApi, KuboError};
+use tracing::{debug, info, warn, error};
+use ipfs_unixfs::{unixfs, unixfs::{dag_pb, unixfs_pb, UnixfsNode}};
 
-const PREFERRED_KEYS_IN_ORDER : &[&str] = &["hyphae", "myceli", "space", "", "self"];
+const PREFERRED_KEYS_IN_ORDER: &[&str] = &["hyphae", "myceli", "space", "", "self"];
 
 pub(crate) struct Indexer<'a> {
     kubo: &'a KuboApi,
     // myceli: &'a MyceliApi,
     key: Option<Key>,
     html: String,
+    main: Index,
+    resolved: Option<String>,
+    dir: Option<ipfs_unixfs::Block>,
+    name_target: Option<String>,
+    index_count: usize,
 }
+
+type When = DateTime<Utc>;
+
+#[derive(Debug, Clone, Ord, Eq, PartialEq, Default)]
+struct File {
+    name: String,
+    cid: String,
+    when: When,
+}
+
+struct Index {
+    files: BTreeMap<String, File>,
+    arch: Option<Box<Index>>,
+}
+
+const PARSED: &str = "Already parsed the HTML";
+const DATA_LINE_START: &str = "<!-- ";
 
 impl<'a> Indexer<'a> {
     // pub fn new(kubo: &'a KuboApi, myceli: &'a MyceliApi) -> Self {
     pub fn new(kubo: &'a KuboApi) -> Self {
-        Self{kubo, key: None, html: String::new()}
+        Self { kubo, key: None, html: String::new(), main: Index::default(), resolved: None, name_target: None, dir: None, index_count: 0 }
     }
-    pub fn step(&mut self) -> Result<bool> {
-        if self.key.is_none() {
+    pub fn step(&mut self, files: &BTreeMap<String, TransmissionBlock>) -> Result<bool> {
+        if self.add_files(files) {
+            info!("Added some new file(s).");
+            Ok(true)
+        } else if self.key.is_none() {
             let known = self.kubo.list_keys()?.keys;
             debug!("All keys Kubo currently knows: {:?}", &known);
             for pref in PREFERRED_KEYS_IN_ORDER {
-                self.key = known.iter().find(|k| k.name == *pref).map(|k|k.clone());
-                if self.key.is_some()  {
-                    info!("Will be publishing to IPNS name '{}'", &pref);
+                self.key = known.iter().find(|k| k.name == *pref).map(|k| k.clone());
+                if self.key.is_some() {
+                    info!("Will be publishing to IPNS name '{}'", & pref);
+                    break;
                 } else {
-                    warn!("Kubo knows of no key by the name '{}', so it will not be used.", &pref);
+                    warn!("Kubo knows of no key by the name '{}', so it will not be used.", & pref);
                 }
             }
             if self.key.is_none() {
                 self.key = known.into_iter().next();
                 if self.key.is_some() {
-                    warn!("Found no preferred keys, so using one arbitrarily: {:?}", &self.key);
+                    warn!("Found no preferred keys, so using one arbitrarily: {:?}", & self.key);
                 }
             }
             Ok(self.key.is_some())
+        } else if self.resolved.is_none() {
+            match self.kubo.resolve_name(&self.key.clone().unwrap().id) {
+                Ok(ipfs_path) => { self.resolved = Some(ipfs_path) }
+                Err(KuboError::NoSuchName(_)) => {
+                    info!("Our IPNS name does not currently resolve to anything. Presumably we're just getting started from scratch.");
+                    self.resolved = Some(String::new());
+                }
+                Err(e) => error!("Error resolving IPNS name: {:?}", & e),
+            }
+            Ok(true)
+        } else if self.html.is_empty() {
+            self.fetch_html()?;
+            Ok(true)
+        } else if self.html != PARSED {
+            self.parse_html(files);
+            Ok(true)
+        } else if let Some(d) = &self.dir {
+            self.kubo.put_block(d.cid().to_string().as_str(), &TransmissionBlock {
+                data: d.data().to_vec(),
+                cid: vec![],
+                links: vec![],
+                filename: None,
+            })?;
+            info!("Uploaded the directory node {}", &d.cid());
+            self.name_target = Some(d.cid().to_string());
+            self.dir = None;
+            Ok(true)
+        } else if let (Some(target), Some(key)) = (&self.name_target, &self.key) {
+            let path = "/ipfs/".to_string() + target;
+            debug!("About to attempt to publish...");
+            self.kubo.publish(key.name.as_str(), &path)?;
+            info!("Published. See results at http://localhost:8080/ipns/{}", key.id);
+            self.name_target = None;
+            Ok(true)
+        } else if self.index_count == files.len() {
+            debug!("Waiting for new files to arrive.");
+            Ok(false)
+        } else if let Ok([index, dir]) = self.main.build() {
+            info!("Will upload index.html {} now, directory {} later", index.cid().to_string(), dir.cid().to_string());
+            self.kubo.put_block(index.cid().to_string().as_str(), &TransmissionBlock {
+                data: index.data().to_vec(),
+                cid: vec![],
+                links: vec![],
+                filename: None,
+            })?;
+            self.dir = Some(dir);
+            self.index_count = files.len();
+            Ok(true)
         } else {
-            info!("TODO");
+            warn!("troubles");
             Ok(false)
         }
+    }
+    fn add_files(&mut self, files: &BTreeMap<String, TransmissionBlock>) -> bool {
+        if self.html != PARSED {
+            debug!("We don't yet have an 'old' index to check for files with existing timestamps.");
+            return false;
+        }
+        let when = Utc::now();
+        let mut result = false;
+        for (cid, tblock) in files {
+            if self.main.files.contains_key(cid) {
+                debug!("{} already included in main index", cid);
+            } else if self.main.is_archived(cid) {
+                debug!("{} already included in archive index", cid);
+            } else if let Some(name) = &tblock.filename {
+                let file = File { name: name.clone(), cid: cid.clone(), when };
+                info!("Encountered new file: {:?} aka {:?}", & file, &tblock);
+                self.main.files.insert(cid.clone(), file);
+                result = true;
+            } else {
+                debug!("Not indexing unnamed chunk: {}", & cid);
+            }
+        }
+        result
+    }
+    fn fetch_html(&mut self) -> Result<()> {
+        if let (Some(path), Some(key)) = (&self.resolved, &self.key) {
+            if path.is_empty() {
+                info!("We have no HTML to parse.");
+                self.html = PARSED.to_string();
+            } else {
+                let bytes = self.kubo.get(format!("/ipns/{}/index.html", key.id).as_str())?;
+                info!("Fetched {} bytes of index.html", bytes.len());
+                self.html = String::from_utf8(bytes)?;
+            }
+            Ok(())
+        } else {
+            unreachable!()
+        }
+    }
+    fn parse_html(&mut self, files: &BTreeMap<String, TransmissionBlock>) {
+        for line in self.html.split("\n") {
+            if line.starts_with(DATA_LINE_START) {
+                let mut toks = line.split_whitespace();
+                toks.next();//discard open comment
+                let mut f = File::default();
+                if let Some(w) = toks.next().and_then(|s| DateTime::parse_from_rfc3339(s).ok()) {
+                    f.when = w.into();
+                } else {
+                    warn!("Trouble parsing timestamp.");
+                    continue;
+                }
+                if let Some(cid) = toks.next() {
+                    f.cid = cid.to_owned();
+                } else {
+                    warn!("No CID in data line?");
+                    continue;
+                }
+                if let Some(name) = toks.next() {
+                    f.name = name.to_owned();
+                } else {
+                    warn!("No filename in data line");
+                    continue;
+                }
+                if files.contains_key(&f.cid) {
+                    info!("Re-found old file={:?}", &f);
+                    self.main.files.insert(f.cid.clone(), f);
+                } else {
+                    info!("Missing old file={:?}", &f);
+                    if self.main.arch.is_none() {
+                        self.main.arch = Some(Box::new(Index::default()));
+                    }
+                    self.main.arch.as_mut().unwrap().files.insert(f.cid.clone(), f);
+                }
+            }
+        }
+        self.html = PARSED.to_string();
+    }
+}
+
+impl Index {
+    fn is_archived(&self, cid: &String) -> bool {
+        if let Some(a) = &self.arch {
+            (*a).files.contains_key(cid) || (*a).is_archived(cid)
+        } else {
+            false
+        }
+    }
+    fn build(&self) -> Result<[ipfs_unixfs::Block; 2]> {
+        let mut html = "<html><title>Space Files</title><body><table border=1><tr><th>Name</th><th>Import Time</th></tr>\n".to_string();
+        let mut links = Vec::new();
+        let mut files: Vec<File> = self.files.values().map(|f| (*f).clone()).collect();
+        files.sort();
+        let mut taken: HashSet<String> = HashSet::new();
+        taken.insert("archive".to_string());
+        taken.insert("index.html".to_string());
+        let mut i = 0;
+        for f in files {
+            if html.len() > 1_000_000 {
+                warn!("index.html limited to fit in a single UnixFS node.");
+                break;
+            }
+            let mut real = f.name.clone();
+            while !taken.insert(real.clone()) {
+                real = i.to_string() + real.as_str();
+                i += 1;
+            }
+            let cid = Cid::try_from(f.cid.as_str());
+            if cid.is_err() {
+                continue;
+            }
+            let cid = cid?;
+            info!("Link: {}={}={}", &f.name, &real, &f.cid);
+            links.push(dag_pb::PbLink {
+                hash: Some(cid.to_bytes()),
+                name: Some(real.clone()),
+                tsize: None,
+            });
+            let when_str = f.when.to_rfc3339();
+            html.push_str(DATA_LINE_START);
+            html.push_str(&when_str);
+            html.push(' ');
+            html.push_str(&cid.to_string());
+            html.push(' ');
+            html.push_str(&f.name);
+            html.push_str(" -->\n");
+
+            html.push_str("<tr><td><a href='");
+            html.push_str(&real);
+            html.push_str("'>");
+            html.push_str(&f.name);
+            html.push_str("</a></td><td>");
+            html.push_str(&when_str);
+            html.push_str("</td></tr>\n");
+        }
+        html.push_str("</table></body></html>");
+        let html_bytes = Bytes::from(html);
+        let byte_count = html_bytes.len() as u64;
+        let node = UnixfsNode::Raw(html_bytes);
+        let index_block = node.encode()?;
+        links.push(dag_pb::PbLink {
+            hash: Some(index_block.cid().to_bytes()),
+            name: Some("index.html".to_string()),
+            tsize: Some(byte_count),
+        });
+        let inner = unixfs_pb::Data {
+            r#type: unixfs::DataType::Directory as i32,
+            ..Default::default()
+        };
+        let outer = ipfs_unixfs::builder::encode_unixfs_pb(&inner, links)?;
+        let node = UnixfsNode::Directory(unixfs::Node { outer, inner });
+        Ok([index_block, node.encode()?])
+    }
+}
+
+impl Default for Index {
+    fn default() -> Self {
+        Self {
+            files: BTreeMap::new(),
+            arch: None,
+        }
+    }
+}
+
+impl PartialOrd<File> for File {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        for o in &[self.when.cmp(&other.when).reverse(), self.name.cmp(&other.name)] {
+            if !o.is_eq() {
+                return Some(*o);
+            }
+        }
+        Some(self.cid.cmp(&other.cid))
     }
 }

--- a/hyphae/src/indexer.rs
+++ b/hyphae/src/indexer.rs
@@ -1,0 +1,43 @@
+use super::kubo_api::{Key, KuboApi};
+use anyhow::Result;
+use tracing::{debug, info, warn};
+
+const PREFERRED_KEYS_IN_ORDER : &[&str] = &["hyphae", "myceli", "space", "", "self"];
+
+pub(crate) struct Indexer<'a> {
+    kubo: &'a KuboApi,
+    // myceli: &'a MyceliApi,
+    key: Option<Key>,
+    html: String,
+}
+
+impl<'a> Indexer<'a> {
+    // pub fn new(kubo: &'a KuboApi, myceli: &'a MyceliApi) -> Self {
+    pub fn new(kubo: &'a KuboApi) -> Self {
+        Self{kubo, key: None, html: String::new()}
+    }
+    pub fn step(&mut self) -> Result<bool> {
+        if self.key.is_none() {
+            let known = self.kubo.list_keys()?.keys;
+            debug!("All keys Kubo currently knows: {:?}", &known);
+            for pref in PREFERRED_KEYS_IN_ORDER {
+                self.key = known.iter().find(|k| k.name == *pref).map(|k|k.clone());
+                if self.key.is_some()  {
+                    info!("Will be publishing to IPNS name '{}'", &pref);
+                } else {
+                    warn!("Kubo knows of no key by the name '{}', so it will not be used.", &pref);
+                }
+            }
+            if self.key.is_none() {
+                self.key = known.into_iter().next();
+                if self.key.is_some() {
+                    warn!("Found no preferred keys, so using one arbitrarily: {:?}", &self.key);
+                }
+            }
+            Ok(self.key.is_some())
+        } else {
+            info!("TODO");
+            Ok(false)
+        }
+    }
+}

--- a/hyphae/src/kubo_api.rs
+++ b/hyphae/src/kubo_api.rs
@@ -5,7 +5,7 @@ use reqwest::blocking::Client;
 use serde_json::Value;
 use std::time::Duration;
 use serde::Deserialize;
-use tracing::{info, warn, debug};
+use tracing::{ warn, debug};
 
 use crate::DAG_PB_CODEC_PREFIX;
 
@@ -20,6 +20,18 @@ pub struct PutResp {
     pub key: String,
     #[serde(alias = "Size")]
     pub size: u64,
+}
+#[derive(Debug,Deserialize,Clone)]
+pub struct Key {
+    #[serde(alias = "Id")]
+    pub id: String,
+    #[serde(alias = "Name")]
+    pub name: String,
+}
+#[derive(Debug,Deserialize)]
+pub struct KeyListResp {
+    #[serde(alias = "Keys")]
+    pub keys: Vec<Key>
 }
 
 impl KuboApi {
@@ -64,9 +76,15 @@ impl KuboApi {
             .post(put_block_url)
             .multipart(form)
             .send()?
-            // .bytes();
             .json::<PutResp>()?;
-        // info!("Synced: {:?}", &resp);
+        Ok(resp)
+    }
+    pub fn list_keys(&self) -> Result<KeyListResp> {
+        let  put_block_url = format!("{}/key/list", self.address);
+        let resp = self.client
+            .post(put_block_url)
+            .send()?
+            .json::<KeyListResp>()?;
         Ok(resp)
     }
 }

--- a/hyphae/src/kubo_api.rs
+++ b/hyphae/src/kubo_api.rs
@@ -1,43 +1,25 @@
-use anyhow::Result;
 use messages::TransmissionBlock;
 use reqwest::blocking::multipart;
 use reqwest::blocking::Client;
 use serde_json::Value;
 use std::time::Duration;
 use serde::Deserialize;
-use tracing::{ warn, debug};
+use tracing::{warn, debug};
+use thiserror::Error;
 
 use crate::DAG_PB_CODEC_PREFIX;
+
+type Result<T> = std::result::Result<T, KuboError>;
 
 pub struct KuboApi {
     address: String,
     client: Client,
 }
 
-#[derive(Debug,Deserialize)]
-pub struct PutResp {
-    #[serde(alias = "Key")]
-    pub key: String,
-    #[serde(alias = "Size")]
-    pub size: u64,
-}
-#[derive(Debug,Deserialize,Clone)]
-pub struct Key {
-    #[serde(alias = "Id")]
-    pub id: String,
-    #[serde(alias = "Name")]
-    pub name: String,
-}
-#[derive(Debug,Deserialize)]
-pub struct KeyListResp {
-    #[serde(alias = "Keys")]
-    pub keys: Vec<Key>
-}
-
 impl KuboApi {
     pub fn new(address: &str) -> Self {
         let client = Client::builder()
-            .timeout(Duration::from_millis(5000))
+            .timeout(Duration::from_secs(30))
             .build()
             .expect("Failed to build reqwest client");
         KuboApi {
@@ -80,11 +62,122 @@ impl KuboApi {
         Ok(resp)
     }
     pub fn list_keys(&self) -> Result<KeyListResp> {
-        let  put_block_url = format!("{}/key/list", self.address);
+        let url = format!("{}/key/list", self.address);
         let resp = self.client
-            .post(put_block_url)
+            .post(url)
             .send()?
             .json::<KeyListResp>()?;
         Ok(resp)
     }
+    pub fn resolve_name(&self, name: &str) -> Result<String> {
+        let url = format!("{}/name/resolve?arg={}", self.address, name);
+        let resp = self.client
+            .post(url)
+            .send()?
+            .json::<NameResolutionResponse>()?;
+        if resp.code == Some(0) {
+            Err(KuboError::NoSuchName(name.to_string()))
+        } else if let Some(path) = resp.path {
+            Ok(path)
+        } else if let (Some(code), Some(msg)) = (resp.code, resp.message) {
+            Err(KuboError::ServerError(code, msg))
+        } else {
+            Err(KuboError::Unknown)
+        }
+    }
+    pub fn publish(&self, key_name: &str, target_ipfs_path: &str) -> Result<()> {
+        let url = format!("{}/name/publish?arg={}&lifetime=168h&ttl=48h&key={}", self.address, target_ipfs_path, key_name);
+        let resp = self.client
+            .post(url)
+            .send()?
+            .json::<GenericResponse>()?;
+        if resp.message.is_some() {
+            Err(KuboError::ServerError(resp.code.unwrap_or(0), resp.message.unwrap()))
+        } else {
+            Ok(())
+        }
+    }
+    pub fn get(&self, ipfs_path: &str) -> Result<Vec<u8>> {
+        let url = format!("{}/cat?arg={}&progress=false", self.address, ipfs_path);
+        let resp = self.client
+            .post(url)
+            .send()?
+            .bytes()?
+            .to_vec();
+        Ok(resp)
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+pub struct GenericResponse {
+    #[serde(alias = "Key")]
+    pub key: Option<String>,
+
+    #[serde(alias = "Size")]
+    pub size: Option<u64>,
+
+    #[serde(alias = "Id")]
+    pub id: Option<String>,
+
+    #[serde(alias = "Name")]
+    pub name: Option<String>,
+
+    #[serde(alias = "Keys")]
+    pub keys: Option<Vec<Key>>,
+
+    #[serde(alias = "Path")]
+    path: Option<String>,
+
+    #[serde(alias = "Message")]
+    message: Option<String>,
+
+    #[serde(alias = "Code")]
+    code: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PutResp {
+    #[serde(alias = "Key")]
+    pub key: String,
+    #[serde(alias = "Size")]
+    pub size: u64,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Key {
+    #[serde(alias = "Id")]
+    pub id: String,
+    #[serde(alias = "Name")]
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct KeyListResp {
+    #[serde(alias = "Keys")]
+    pub keys: Vec<Key>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct NameResolutionResponse {
+    #[serde(alias = "Path")]
+    path: Option<String>,
+    #[serde(alias = "Message")]
+    message: Option<String>,
+    #[serde(alias = "Code")]
+    code: Option<i64>,
+}
+
+#[derive(Debug, Error)]
+pub enum KuboError {
+    // #[error("JSON response {0} did not contain expected key {1}")]
+    // JsonKeyMissing(String, String),
+    #[error("Networking problem {0}")]
+    ReqwestProblem(#[from] reqwest::Error),
+    #[error("Could not resolve the name {0}")]
+    NoSuchName(String),
+    #[error("The RPC API returned an error: {0}={1}")]
+    ServerError(i64, String),
+    #[error("Something went wrong.")]
+    Unknown,
 }

--- a/hyphae/src/kubo_api.rs
+++ b/hyphae/src/kubo_api.rs
@@ -47,10 +47,18 @@ impl KuboApi {
         }
     }
 
-    pub fn put_block(&self, cid: &str, block: &TransmissionBlock) -> Result<PutResp> {
-        let mut put_block_url = format!("{}/block/put?pin=true", self.address);
+    pub fn put_block(&self, cid: &str, block: &TransmissionBlock, pin: bool) -> Result<PutResp> {
+        let mut put_block_url = format!("{}/block/put", self.address);
+        if pin {
+            put_block_url.push_str("?pin=true")
+        }
         if cid.starts_with(DAG_PB_CODEC_PREFIX) {
-            put_block_url.push_str("&cid-codec=dag-pb");
+            if pin {
+                put_block_url.push('&');
+            } else {
+                put_block_url.push('?');
+            }
+            put_block_url.push_str("cid-codec=dag-pb");
         }
         let form_part = multipart::Part::bytes(block.data.to_owned());
         let form = multipart::Form::new().part("data", form_part);

--- a/hyphae/src/main.rs
+++ b/hyphae/src/main.rs
@@ -59,19 +59,14 @@ fn sync_blocks(kubo: &KuboApi, myceli: &MyceliApi, kubo_blocks: &mut Synchronize
                 continue;
             }
         };
-        match kubo.put_block(&cid, &block) {
+        match kubo.put_block(&cid, &block, true) {
             Err(e) => {
                 error!("Error sending block {cid} to kubo: {e}");
                 all_blocks_synced = false;
             }
             Ok(resp) => {
-                if cid == resp.key {
-                    info!("Synchronized {}", &cid);
-                } else {
-                    error!("Synchronizing {} actually resulted in {}", &cid, resp.key);
-                }
+                debug!("Synchronized {} and got {:?}", &cid, resp);
                 kubo_blocks.insert(cid, block.clone());
-                sleep(Duration::from_millis(500));
             }
         }
     }
@@ -102,38 +97,38 @@ fn main() -> Result<()> {
     info!("Connecting to kubo@{}", cfg.kubo_address);
 
     let kubo = KuboApi::new(&cfg.kubo_address);
-    let mut myceli = MyceliApi::new(
-        &cfg.myceli_address,
-        &cfg.listen_to_myceli_address,
-        cfg.myceli_mtu,
-        cfg.chunk_transmit_throttle,
-    )
-        .expect("Failed to create MyceliAPi");
+    let mut myceli_api: Option<MyceliApi> = None;
     let mut indexer = Indexer::new(&kubo);
     let mut synced = Synchronized::default();
     let mut miss = 0;
     loop {
-        if kubo.check_alive() && myceli.check_alive() {
-            match sync_blocks(&kubo, &myceli, &mut synced) {
-                Err(e) => error!("Error during blocks sync: {e}"),
-                Ok(true) => debug!("Synchronization happened."),
-                Ok(false) => {
-                    if let Err(e) = indexer.step(&synced) {
-                        error!("Trouble indexing: {:?}", &e);
+        if let Some(myceli) = &myceli_api {
+            if kubo.check_alive() && myceli.check_alive() {
+                match sync_blocks(&kubo, myceli, &mut synced) {
+                    Err(e) => error!("Error during blocks sync: {e}"),
+                    Ok(true) => debug!("Synchronization happened."),
+                    Ok(false) => {
+                        if let Err(e) = indexer.step(&synced) {
+                            error!("Trouble indexing: {:?}", &e);
+                        } else {
+                            miss = 0;
+                        }
                     }
                 }
+            } else if miss > 9 {
+                info!("Connection to Myceli failed {} times, resetting.", miss);
+                myceli_api = None;
+                miss = 0;
+            } else {
+                miss += 1;
             }
-        } else if miss > 9 {
-            info!("Connection to Myceli failed {} times, resetting.", miss);
-            miss = 0;
-            myceli = MyceliApi::new(
+        } else {
+            myceli_api = MyceliApi::new(
                 &cfg.myceli_address,
                 &cfg.listen_to_myceli_address,
                 cfg.myceli_mtu,
                 cfg.chunk_transmit_throttle,
-            ).expect("Failed to reset MyceliAPi");
-        } else {
-            miss += 1;
+            ).ok();
         }
         sleep(Duration::from_millis(cfg.sync_interval));
     }

--- a/hyphae/src/main.rs
+++ b/hyphae/src/main.rs
@@ -123,6 +123,7 @@ fn main() -> Result<()> {
                 miss += 1;
             }
         } else {
+            info!("Creating a Myceli API object...");
             myceli_api = MyceliApi::new(
                 &cfg.myceli_address,
                 &cfg.listen_to_myceli_address,

--- a/hyphae/src/main.rs
+++ b/hyphae/src/main.rs
@@ -3,19 +3,18 @@ mod kubo_api;
 mod myceli_api;
 mod indexer;
 
-use std::ops::Sub;
-
 use anyhow::Result;
 use clap::Parser;
 use config::Config;
 use kubo_api::KuboApi;
 use myceli_api::MyceliApi;
 use indexer::Indexer;
-use std::collections::HashSet;
+use std::collections::BTreeMap;
 use std::thread::sleep;
 use std::time::Duration;
 use tracing::{error, info, metadata::LevelFilter, warn, debug};
 use tracing_subscriber::{fmt, EnvFilter};
+use messages::TransmissionBlock;
 
 pub const RAW_CODEC_PREFIX: &str = "bafkrei";
 pub const DAG_PB_CODEC_PREFIX: &str = "bafybei";
@@ -27,51 +26,30 @@ struct Args {
     config_path: Option<String>,
 }
 
-fn get_missing_blocks(
-    mut myceli_blocks: Vec<String>,
-    kubo_blocks: &HashSet<String>,
-) -> HashSet<String> {
-    // Kubo will take blocks with the dag-pb codec and convert them to raw blocks, which throws off the diff.
-    // So we will replace any cids with the dag-pb codec with a raw codec for the purposes of the diff,
-    // but the actual sync will be done on the dag-pb cids.
-    let mut raw_from_dag_pb_blocks: Vec<String> = vec![];
-    for block in myceli_blocks.iter_mut() {
-        if block.starts_with(DAG_PB_CODEC_PREFIX) {
-            let pb_to_raw_cid = block.replace(DAG_PB_CODEC_PREFIX, RAW_CODEC_PREFIX);
-            raw_from_dag_pb_blocks.push(pb_to_raw_cid.to_string());
-            *block = pb_to_raw_cid.to_string();
-        }
-    }
+type Synchronized = BTreeMap<String, TransmissionBlock>;
 
-    let myceli_blocks = HashSet::from_iter(myceli_blocks.into_iter());
-    let mut missing_blocks = myceli_blocks.sub(&kubo_blocks);
-    for cid in raw_from_dag_pb_blocks {
-        if missing_blocks.contains(&cid) {
-            let as_dag = cid.replace(RAW_CODEC_PREFIX, DAG_PB_CODEC_PREFIX);
-            if !  kubo_blocks.contains(&as_dag) {
-                missing_blocks.insert(as_dag);
-            }
-            missing_blocks.remove(&cid);
-        }
-    }
-    missing_blocks
+fn get_missing_blocks(
+    myceli_blocks: Vec<String>,
+    kubo_blocks: &Synchronized,
+) -> Vec<String> {
+    myceli_blocks.into_iter().filter_map(|b| if kubo_blocks.contains_key(&b) {
+        None
+    } else {
+        Some(b)
+    }).collect()
 }
 
-fn sync_blocks(kubo: &KuboApi, myceli: &MyceliApi, kubo_blocks: &mut HashSet<String>) -> Result<bool> {
+fn sync_blocks(kubo: &KuboApi, myceli: &MyceliApi, kubo_blocks: &mut Synchronized) -> Result<bool> {
     let myceli_blocks = myceli.get_available_blocks()?;
-    let missing_blocks = get_missing_blocks(myceli_blocks, kubo_blocks);
+    let missing_blocks = get_missing_blocks(myceli_blocks, &kubo_blocks);
     if missing_blocks.is_empty() {
-        return Ok(true);
+        return Ok(false);
     }
     debug!("Begin syncing {} myceli blocks to kubo", missing_blocks.len());
     let mut all_blocks_synced = true;
 
     for cid in missing_blocks {
-        if kubo_blocks.contains(&cid) {
-            warn!("Set subtraction somehow missed {}", &cid);
-            continue;
-        }
-        info!("Syncing block {cid} from myceli to kubo");
+        debug!("Looking to synchronize block {cid} from myceli to kubo");
         let block = match myceli.get_block(&cid) {
             Ok(block) => block,
             Err(e) => {
@@ -82,25 +60,29 @@ fn sync_blocks(kubo: &KuboApi, myceli: &MyceliApi, kubo_blocks: &mut HashSet<Str
             }
         };
         match kubo.put_block(&cid, &block) {
-            Err(e) =>  {
+            Err(e) => {
                 error!("Error sending block {cid} to kubo: {e}");
                 all_blocks_synced = false;
-            },
+            }
             Ok(resp) => {
-                info!("Synchronized {} as {}", &cid, resp.key);
-                kubo_blocks.insert(cid);
-                kubo_blocks.insert(resp.key);
-                return Ok(false);
+                if cid == resp.key {
+                    info!("Synchronized {}", &cid);
+                } else {
+                    error!("Synchronized {} as {}", &cid, resp.key);
+                }
+                kubo_blocks.insert(cid, block.clone());
+                sleep(Duration::from_millis(500));
             }
         }
     }
 
     if all_blocks_synced {
         info!("All myceli blocks are synced.");
+        Ok(true)
     } else {
         warn!("Not all myceli blocks were able to sync, check logs for specific errors");
+        Ok(false)
     }
-    Ok(false)
 }
 
 fn main() -> Result<()> {
@@ -126,15 +108,19 @@ fn main() -> Result<()> {
         cfg.myceli_mtu,
         cfg.chunk_transmit_throttle,
     )
-    .expect("Failed to create MyceliAPi");
+        .expect("Failed to create MyceliAPi");
     let mut indexer = Indexer::new(&kubo);
-    let mut synced = HashSet::default();
+    let mut synced = Synchronized::default();
     loop {
         if kubo.check_alive() && myceli.check_alive() {
             match sync_blocks(&kubo, &myceli, &mut synced) {
                 Err(e) => error!("Error during blocks sync: {e}"),
-                Ok(true) => {indexer.step().ok();},
-                Ok(false) => debug!("Synchronization happened."),
+                Ok(true) => debug!("Synchronization happened."),
+                Ok(false) => {
+                    if let Err(e) = indexer.step(&synced) {
+                        error!("Trouble indexing: {:?}", &e);
+                    }
+                }
             }
         }
         sleep(Duration::from_millis(cfg.sync_interval));

--- a/hyphae/src/main.rs
+++ b/hyphae/src/main.rs
@@ -41,7 +41,7 @@ fn get_missing_blocks(
 
 fn sync_blocks(kubo: &KuboApi, myceli: &MyceliApi, kubo_blocks: &mut Synchronized) -> Result<bool> {
     let myceli_blocks = myceli.get_available_blocks()?;
-    let missing_blocks = get_missing_blocks(myceli_blocks, &kubo_blocks);
+    let missing_blocks = get_missing_blocks(myceli_blocks, kubo_blocks);
     if missing_blocks.is_empty() {
         return Ok(false);
     }

--- a/hyphae/src/myceli_api.rs
+++ b/hyphae/src/myceli_api.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use messages::{ApplicationAPI, DataProtocol, Message, TransmissionBlock};
 use std::rc::Rc;
 use std::time::Duration;
-use tracing::{info, warn, debug};
+use tracing::{ warn, debug};
 use transports::{Transport, UdpTransport};
 
 pub struct MyceliApi {

--- a/hyphae/src/myceli_api.rs
+++ b/hyphae/src/myceli_api.rs
@@ -55,7 +55,6 @@ impl MyceliApi {
             }
             Err(e) => {
                 warn!("Could not contact myceli at this time: {e}");
-                std::thread::sleep(Duration::from_secs(1));
                 false
             }
         }
@@ -75,7 +74,6 @@ impl MyceliApi {
                     bail!("Error trying to fetch available block list: {e:?}");
                 }
             }
-            std::thread::sleep(Duration::from_secs(1));
         }
         Err(MyceliError::GiveUp.into())
     }
@@ -94,7 +92,6 @@ impl MyceliApi {
                     warn!("Received wrong resp for RequestBlock: {other:?}");
                 }
             }
-            std::thread::sleep(Duration::from_secs(1));
         }
         Err(MyceliError::GiveUp.into())
     }

--- a/hyphae/src/myceli_api.rs
+++ b/hyphae/src/myceli_api.rs
@@ -69,7 +69,7 @@ impl MyceliApi {
                     return Ok(cids);
                 }
                 Ok(other) => {
-                    warn!("Received wrong resp for RequestAvailableBlocks: {other:?}");
+                    debug!("Received wrong resp for RequestAvailableBlocks: {other:?}");
                 }
                 Err(e) => {
                     bail!("Error trying to fetch available block list: {e:?}");

--- a/hyphae/src/myceli_api.rs
+++ b/hyphae/src/myceli_api.rs
@@ -1,8 +1,8 @@
 use anyhow::{bail, Result};
 use messages::{ApplicationAPI, DataProtocol, Message, TransmissionBlock};
-use std::rc::Rc;
-use std::time::Duration;
-use tracing::{ warn, debug};
+use std::{rc::Rc, time::Duration};
+use thiserror::Error;
+use tracing::{warn, debug};
 use transports::{Transport, UdpTransport};
 
 pub struct MyceliApi {
@@ -50,11 +50,12 @@ impl MyceliApi {
                 true
             }
             Ok(other_msg) => {
-                warn!("Myceli returned wrong version message: {other_msg:?}");
-                false
+                debug!("Got unexpected message, which nonetheless proves myceli is alive: {:?}", other_msg);
+                true
             }
             Err(e) => {
                 warn!("Could not contact myceli at this time: {e}");
+                std::thread::sleep(Duration::from_secs(1));
                 false
             }
         }
@@ -62,24 +63,45 @@ impl MyceliApi {
 
     pub fn get_available_blocks(&self) -> Result<Vec<String>> {
         self.send_msg(Message::request_available_blocks())?;
-        match self.recv_msg() {
-            Ok(Message::ApplicationAPI(ApplicationAPI::AvailableBlocks { cids })) => Ok(cids),
-            other => {
-                // TODO: extract out to macro which logs and bails
-                warn!("Received wrong resp for RequestAvailableBlocks: {other:?}");
-                bail!("Received wrong resp for RequestAvailableBlocks: {other:?}")
+        for _ in 0..9 {
+            match self.recv_msg() {
+                Ok(Message::ApplicationAPI(ApplicationAPI::AvailableBlocks { cids })) => {
+                    return Ok(cids);
+                }
+                Ok(other) => {
+                    warn!("Received wrong resp for RequestAvailableBlocks: {other:?}");
+                }
+                Err(e) => {
+                    bail!("Error trying to fetch available block list: {e:?}");
+                }
             }
+            std::thread::sleep(Duration::from_secs(1));
         }
+        Err(MyceliError::GiveUp.into())
     }
 
     pub fn get_block(&self, cid: &str) -> Result<TransmissionBlock> {
         self.send_msg(Message::transmit_block(cid, &self.listen_address))?;
-        match self.recv_msg() {
-            Ok(Message::DataProtocol(DataProtocol::Block(block))) => Ok(block),
-            other => {
-                warn!("Received wrong resp for RequestBlock: {other:?}");
-                bail!("Received wrong resp for RequestBlock: {other:?}")
+        for _ in 0..9 {
+            match self.recv_msg() {
+                Ok(Message::DataProtocol(DataProtocol::Block(block))) => {
+                    return Ok(block);
+                }
+                Err(e) => {
+                    bail!("Received wrong resp for RequestBlock: {e:?}");
+                }
+                other => {
+                    warn!("Received wrong resp for RequestBlock: {other:?}");
+                }
             }
+            std::thread::sleep(Duration::from_secs(1));
         }
+        Err(MyceliError::GiveUp.into())
     }
+}
+
+#[derive(Debug, Error)]
+pub enum MyceliError {
+    #[error("Got the wrong response too many times")]
+    GiveUp,
 }

--- a/ipfs-unixfs/src/builder.rs
+++ b/ipfs-unixfs/src/builder.rs
@@ -33,7 +33,7 @@ pub enum Directory {
 }
 
 /// A basic / flat directory
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Default)]
 pub struct BasicDirectory {
     name: String,
     entries: Vec<Entry>,
@@ -187,7 +187,7 @@ impl File {
         current.expect("must not be empty")
     }
 
-    pub async fn encode(self) -> Result<impl Stream<Item = Result<Block>>> {
+    pub async fn encode(self) -> Result<impl Stream<Item=Result<Block>>> {
         let reader = match self.content {
             Content::Path(path) => {
                 let f = tokio::fs::File::open(path).await?;
@@ -571,7 +571,7 @@ impl SymlinkBuilder {
     }
 }
 
-pub(crate) fn encode_unixfs_pb(
+pub fn encode_unixfs_pb(
     inner: &unixfs_pb::Data,
     links: Vec<dag_pb::PbLink>,
 ) -> Result<dag_pb::PbNode> {
@@ -596,7 +596,7 @@ pub struct Config {
     pub chunker: Option<ChunkerConfig>,
 }
 
-#[async_recursion(?Send)]
+#[async_recursion(? Send)]
 async fn make_dir_from_path<P: Into<PathBuf>>(
     path: P,
     chunker: Chunker,
@@ -745,6 +745,7 @@ mod tests {
         // TODO: check content
         Ok(())
     }
+
     #[cfg(not(windows))]
     #[tokio::test]
     async fn symlink_from_disk_test() -> Result<()> {
@@ -760,6 +761,7 @@ mod tests {
         assert_eq!(expect_target, got_symlink.target);
         Ok(())
     }
+
     #[tokio::test]
     async fn test_builder_stream_large() -> Result<()> {
         // Create a directory
@@ -887,7 +889,7 @@ mod tests {
             Chunker::Fixed(chunker::Fixed::default()),
             DEFAULT_DEGREE,
         )
-        .await?;
+            .await?;
 
         let basic_entries = |dir: Directory| match dir {
             Directory::Basic(basic) => basic.entries,

--- a/ipfs-unixfs/src/unixfs.rs
+++ b/ipfs-unixfs/src/unixfs.rs
@@ -17,18 +17,18 @@ use crate::{
     types::{Block, Link, LinkRef, Links, PbLinks},
 };
 
-pub(crate) mod unixfs_pb {
+pub mod unixfs_pb {
     #![allow(clippy::all)]
     include!(concat!(env!("OUT_DIR"), "/unixfs_pb.rs"));
 }
 
-pub(crate) mod dag_pb {
+pub mod dag_pb {
     #![allow(clippy::all)]
     include!(concat!(env!("OUT_DIR"), "/merkledag_pb.rs"));
 }
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, num_enum::IntoPrimitive, num_enum::TryFromPrimitive,
+Debug, Clone, Copy, PartialEq, Eq, num_enum::IntoPrimitive, num_enum::TryFromPrimitive,
 )]
 #[repr(i32)]
 pub enum DataType {
@@ -71,8 +71,8 @@ pub enum UnixfsNode {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Node {
-    pub(super) outer: dag_pb::PbNode,
-    pub(super) inner: unixfs_pb::Data,
+    pub outer: dag_pb::PbNode,
+    pub inner: unixfs_pb::Data,
 }
 
 impl Node {

--- a/local-storage/src/storage.rs
+++ b/local-storage/src/storage.rs
@@ -72,8 +72,7 @@ impl Storage {
             if let Some(filename) = path.file_name().and_then(|p| p.to_str()) {
                 self.provider.name_dag(&root_cid, filename)?;
             }
-            info!("Imported path {} to {}", path.display(), root_cid);
-            info!("Importing {} blocks for {root_cid}", blocks.len());
+            info!("Imported path {} to {} in {} blocks", path.display(), root_cid, blocks.len());
             Ok(root_cid)
         } else {
             bail!("Failed to find root block for {path:?}")
@@ -81,9 +80,9 @@ impl Storage {
     }
 
     pub fn export_cid(&self, cid: &str, path: &Path) -> Result<()> {
-        info!("Exporting {cid} to {}", path.display());
         let check_missing_blocks = self.get_missing_dag_blocks(cid)?;
         if !check_missing_blocks.is_empty() {
+            error!("Can't export {cid} to {}, because we're missing blocks: {:?}", path.display(), check_missing_blocks);
             bail!(StorageError::DagIncomplete(cid.to_string()))
         }
         // Fetch all blocks tied to links under given cid
@@ -97,6 +96,7 @@ impl Storage {
             }
         }
         output_file.sync_all()?;
+        info!("Exported {cid} to {}", path.display());
         Ok(())
     }
 

--- a/transports/src/chunking.rs
+++ b/transports/src/chunking.rs
@@ -5,6 +5,7 @@ use messages::Message;
 use parity_scale_codec::{Decode, Encode};
 use parity_scale_codec_derive::{Decode as ParityDecode, Encode as ParityEncode};
 use serde::Serialize;
+use tracing::error;
 
 // This MessageContainer struct is intended to be used inside of the chunkers
 // for verification of Message integrity during the chunking/assembly process
@@ -40,7 +41,12 @@ impl MessageContainer {
     pub fn verify_cid(&self) -> Result<bool> {
         let original_cid = Cid::try_from(self.cid.clone())?;
         let regenerated_cid = MessageContainer::gen_cid(&self.message.to_bytes());
-        Ok(original_cid == regenerated_cid)
+        if original_cid == regenerated_cid {
+            Ok(true)
+        } else {
+            error!("CID mismatch: provided={} deduced={}", original_cid.to_string(), regenerated_cid.to_string());
+            Ok(false)
+        }
     }
 
     pub fn from_bytes(bytes: &mut &[u8]) -> Result<Self> {


### PR DESCRIPTION
* No longer queries Kubo for the full list of every block (which was only reasonable if Kubo is empty)
* Pins the files it uploads
* No longer rapid-fires a ton of Kubo requests in a very short period of time
* Puts the most recent entries (could be a TODO here) in a single DAG
* Writes an html file for that DAG that acts as an index or really log of recent file uploads (if you change a given file name it shows up repeatedly for each new version)
* Publishes that DAG to IPNS - see my test example here https://ipfs.io/ipns/k51qzi5uqu5dluef7p1gs1dfwlofxtt6orjqs4qox3wcvi7u4k1drdy1yfg1q4/

![image](https://github.com/ipfs-shipyard/space/assets/97759690/584366a3-3baa-4f4d-82dd-093bf1faad73)
